### PR TITLE
Fix redirect target in createProject route

### DIFF
--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -215,7 +215,7 @@ def createProject():
 
         """, (project_name, session["gh_user"]))
     conn.commit()
-    return redirect(url_for("listProject", project_name = project_name), code=302)
+    return redirect(url_for("listProjectCrashes", project_name = project_name), code=302)
 
 @app.route('/projects/<project_name>/builds')
 @login_required


### PR DESCRIPTION
## Summary
- fix wrong url_for call that caused runtime error when creating a project

## Testing
- `python -m py_compile esp-crash-server/server.py`

------
https://chatgpt.com/codex/tasks/task_e_683f613f4988832d94f8d811440d92dc