### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ coredump_upload
 
 ## License
 
-This component is provided under Apache 2.0 license, see [LICENSE](LICENSE.md) file for details.
+This component is provided under Apache 2.0 license, see [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Contributing
 
-Please check [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+Please check the repository for contribution guidelines.
 
 
 ## How to use esp-crash


### PR DESCRIPTION
## Summary
- update README to link to `LICENSE.txt`
- remove bad link to nonexistent CONTRIBUTING.md

## Testing
- `markdownlint README.md` *(fails: multiple warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683f6ed00ee8832d8bec50c5660269db