### PR TITLE
module aware coredump symbolication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__
 managed_components/*
 dependencies.lock
 docker-compose.yml
+.env
 data
 db

--- a/README.md
+++ b/README.md
@@ -156,6 +156,175 @@ coredump_upload  [-e] [url] [filename]
    -e, --erase  Erase after successful upload
 ```
 
+## Dynamically loaded ELF modules
+
+If your firmware loads ELF modules at runtime (for example with an ELF loader /
+mod loader), those modules are not part of your main application ELF, so the
+backend can't symbolicate their stack frames — crashes inside a module show up
+as raw addresses.
+
+The device records a small **module registry** in a `COREDUMP_DRAM_ATTR`
+variable, so it is captured inside every coredump. Each record holds the
+module's name, the SHA1 of the over-the-wire `.app` bytes, and its section
+runtime addresses. There are two ways to use it:
+
+- **Server-side (automatic):** pre-upload each module's debug ELF, keyed by the
+  SHA1 of its `.app` bytes. When a dump arrives, the backend reads the registry,
+  matches each module by SHA1, and symbolicates automatically.
+- **Local:** run `esp-crash-server/decode_module_coredump.py` against a dump you
+  downloaded, supplying each module ELF by name. The script reads the registry,
+  generates a GDB `add-symbol-file` line per module (placing each section at its
+  on-device runtime address), and hands it to `esp-coredump`.
+
+### Uploading module ELFs
+
+So the backend can symbolicate module frames, upload each module's **debug** ELF
+keyed by the SHA1 of its over-the-wire `.app` bytes — the same SHA1 the device
+stores in the registry. This is what lets the server match an uploaded ELF to a
+module seen in a dump.
+
+```bash
+SHA1=$(sha1sum your-module.app | awk '{print $1}')
+
+curl -F file=@your-module.debug.elf \
+  "https://esp-crash.wennlund.nu/upload_module_elf?name=your-module&app_sha1=$SHA1"
+
+OR compressed
+
+SHA1=$(sha1sum your-module.app | awk '{print $1}')
+bzip2 -c your-module.debug.elf | curl -F file=@- \
+  "https://esp-crash.wennlund.nu/upload_module_elf?name=your-module&app_sha1=$SHA1"
+```
+
+Hash the `.app` bytes the device actually receives (the signed payload), but
+upload the unstripped `.debug.elf` so symbols are available. `app_sha1` must be
+40 hex characters. Like the build-file upload, this fits neatly into CI.
+
+### Decoding locally with the script
+
+```bash
+python esp-crash-server/decode_module_coredump.py info \
+    --core crash.dmp \
+    --prog build/your-app.elf \
+    --module-elf ems-goodwe=modules/ems-goodwe/build/ems-goodwe.app.elf
+```
+
+- `info` prints a symbolicated backtrace; `dbg` drops you into an interactive
+  GDB session.
+- `--module-elf name=path` is repeatable — supply one per loaded module. The
+  `name` must match the name the module was registered under on-device.
+- Module names found in the dump with no matching `--module-elf` are skipped
+  with a warning; the rest of the dump still decodes.
+
+### On-device registry format
+
+For the script to find your modules, the firmware must expose a registry in this
+exact binary layout (little-endian, 4-byte aligned). It is a magic-tagged header
+followed by a fixed-capacity array of module records; the script scans `PT_LOAD`
+segments of the coredump for the `MODM` magic.
+
+```
+registry { u32 magic = 0x4D4F444D ('MODM'); u8 capacity; u8 pad[3];
+           record  modules[capacity]; }
+record   { char name[64]; u8 sha1[20];
+           section text; section data; section bss; section rodata; }
+section  { u32 addr; u32 v_addr; u32 size; }
+```
+
+`addr` is the **runtime** address of the section (what GDB needs), `v_addr` is
+the ELF link-time virtual address, `size` is the section size. A slot is
+considered occupied only when `name[0] != 0` **and** `text.addr != 0`; zeroed
+slots (free) and slots with a name but `text.addr == 0` (mid-load) are skipped.
+
+### C example
+
+Declare the registry once, in `COREDUMP_DRAM_ATTR` storage so it lands in the
+dump, and populate a slot when you load a module:
+
+```c
+#include "esp_attr.h"   // COREDUMP_DRAM_ATTR
+#include <stdint.h>
+#include <string.h>
+
+#define MOD_MAP_MAGIC        0x4D4F444DU  // 'MODM'
+#define MOD_MAP_MAX_MODULES  4            // your concurrent-module cap
+#define MOD_MAP_NAME_LEN     64
+#define MOD_MAP_SHA1_LEN     20
+
+typedef struct {
+    uint32_t addr;    // runtime address (passed to GDB add-symbol-file)
+    uint32_t v_addr;  // ELF link-time virtual address
+    uint32_t size;
+} mod_map_section_t;
+
+typedef struct {
+    char    name[MOD_MAP_NAME_LEN];
+    uint8_t sha1[MOD_MAP_SHA1_LEN];
+    mod_map_section_t text;
+    mod_map_section_t data;
+    mod_map_section_t bss;
+    mod_map_section_t rodata;
+} mod_record_t;
+
+// Layout is parsed byte-for-byte by decode_module_coredump.py — keep it pinned.
+_Static_assert(sizeof(mod_record_t) == 132, "mod_record layout drifted");
+
+typedef struct {
+    uint32_t magic;
+    uint8_t  capacity;
+    uint8_t  _pad[3];
+    mod_record_t modules[MOD_MAP_MAX_MODULES];
+} mod_map_registry_t;
+
+_Static_assert(offsetof(mod_map_registry_t, modules) == 8, "header drifted");
+
+// COREDUMP_DRAM_ATTR forces this into the .dram2.coredump region captured in
+// every coredump.
+COREDUMP_DRAM_ATTR static mod_map_registry_t s_mod_map = {
+    .magic    = MOD_MAP_MAGIC,
+    .capacity = MOD_MAP_MAX_MODULES,
+};
+
+// Call after a module's ELF is loaded. `sec_*` come from your ELF loader.
+void module_registry_record(const char *name, const uint8_t sha1[20],
+                            const mod_map_section_t *text,
+                            const mod_map_section_t *data,
+                            const mod_map_section_t *bss,
+                            const mod_map_section_t *rodata)
+{
+    for (uint8_t i = 0; i < MOD_MAP_MAX_MODULES; ++i) {
+        mod_record_t *r = &s_mod_map.modules[i];
+        if (r->name[0] != '\0') {
+            continue; // slot taken
+        }
+        memset(r, 0, sizeof(*r));
+        strlcpy(r->name, name, sizeof(r->name));
+        memcpy(r->sha1, sha1, MOD_MAP_SHA1_LEN);
+        r->text = *text; r->data = *data; r->bss = *bss; r->rodata = *rodata;
+        return;
+    }
+    // registry full — module won't be symbolicated, but the dump is still valid
+}
+
+// On unload, zero the slot so it reads as free.
+void module_registry_clear(const char *name)
+{
+    for (uint8_t i = 0; i < MOD_MAP_MAX_MODULES; ++i) {
+        if (strcmp(s_mod_map.modules[i].name, name) == 0) {
+            memset(&s_mod_map.modules[i], 0, sizeof(s_mod_map.modules[i]));
+            return;
+        }
+    }
+}
+```
+
+The `sha1` field is the SHA1 of the over-the-wire `.app` bytes and is the join
+key for **server-side** symbolication: the backend matches it against the
+`app_sha1` you used when uploading the module ELF. The **local** script matches
+modules by name instead, so there `sha1` is only reported for confirmation. If
+you never use server-side symbolication you may leave it zeroed, but populating
+it is what makes the automatic path work.
+
 ## Example Output
 
 

--- a/esp-crash-server/Dockerfile
+++ b/esp-crash-server/Dockerfile
@@ -69,6 +69,7 @@ RUN python -m pip install --no-cache-dir --no-index --find-links=/wheels -r requ
 
 WORKDIR /code
 COPY server.py .
+COPY decode_module_coredump.py /code
 COPY templates/ templates/
 
 ENV FLASK_APP=server.py

--- a/esp-crash-server/db_schema.sql
+++ b/esp-crash-server/db_schema.sql
@@ -1,5 +1,9 @@
 CREATE TABLE IF NOT EXISTS device (device_id SERIAL PRIMARY KEY, ext_device_id TEXT UNIQUE, alias TEXT);
 CREATE TABLE IF NOT EXISTS crash (crash_id SERIAL PRIMARY KEY, "date" TIMESTAMP, project_name TEXT, project_ver TEXT, crash_dmp BYTEA, device_id INTEGER REFERENCES device(device_id) NOT NULL, textsearch TSVECTOR, dump TEXT);
+-- Names of dynamically-loaded modules referenced by the crash, computed once at
+-- cron processing time so the crash list can render "Modules" tags without
+-- parsing every coredump per page load.
+ALTER TABLE crash ADD COLUMN IF NOT EXISTS module_names TEXT[];
 CREATE TABLE IF NOT EXISTS elf_file (elf_file_id SERIAL PRIMARY KEY, "date" TIMESTAMP, project_name TEXT, project_ver TEXT, elf_file BYTEA, file_size INTEGER, project_alias TEXT);
 CREATE TABLE IF NOT EXISTS project_auth (project_auth_id SERIAL PRIMARY KEY, "date" TIMESTAMP, project_name TEXT, github TEXT);
 CREATE INDEX IF NOT EXISTS textsearch_idx ON crash USING GIN (textsearch);
@@ -64,3 +68,14 @@ CREATE INDEX idx_elf_file_project_name ON elf_file (project_name);
 CREATE INDEX idx_crash_project_name_ver ON crash (project_name, project_ver);
 CREATE INDEX idx_project_auth_lookup ON project_auth (project_name, github);
 CREATE INDEX idx_elf_file_project_date ON elf_file (project_name, date DESC);
+
+CREATE TABLE IF NOT EXISTS module_elf (
+    module_elf_id  SERIAL PRIMARY KEY,
+    "date"         TIMESTAMP DEFAULT NOW(),
+    name           TEXT NOT NULL,
+    app_sha1       CHAR(40) NOT NULL UNIQUE,
+    elf_file       BYTEA NOT NULL,
+    file_size      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS module_elf_app_sha1_idx ON module_elf(app_sha1);

--- a/esp-crash-server/decode_module_coredump.py
+++ b/esp-crash-server/decode_module_coredump.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Decode ESP32 core dumps with dynamically loaded ELF module symbols.
+
+The on-device module map embedded in .dram2.coredump is read straight from
+the dump. Just supply each loaded module's ELF, mapped by name.
+
+  python decode_module_coredump.py dbg \
+      --core crash.dmp \
+      --prog build/pulse-ir-hub-esp32.elf \
+      --module-elf ems-goodwe=ems-goodwe/build_bridge/ems-goodwe.app.elf
+
+On-device map format (little-endian, 4-byte aligned):
+  registry { u32 magic=0x4D4F444D ('MODM'); u8 capacity; pad[3];
+             entry modules[capacity]; }   # capacity = CONFIG_MOD_LOADER_MAX_MODULES
+  entry    { char name[64]; u8 sha1[20]; section text; section data;
+             section bss; section rodata; }
+  section  { u32 addr; u32 v_addr; u32 size; }
+
+The array is sparse: a slot is occupied iff name[0] != 0 and its .text addr is
+non-zero. Released slots are zeroed; mid-load slots have a name but a zero .text.
+"""
+
+import argparse
+import io
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from elftools.elf.elffile import ELFFile
+
+MOD_MAP_MAGIC = 0x4D4F444D  # 'MODM' as LE u32
+MOD_MAP_NAME_LEN = 64
+MOD_MAP_SHA1_LEN = 20
+SECTION_SIZE = 12
+ENTRY_SIZE = MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN + 4 * SECTION_SIZE  # 64 + 20 + 48 = 132
+REGISTRY_HEADER_SIZE = 8  # u32 magic + u8 capacity + 3 pad bytes
+
+# The on-device array size is a build-time Kconfig (CONFIG_MOD_LOADER_MAX_MODULES,
+# range 1..32). The registry header records the actual capacity so we never need
+# to guess; this is only the upper bound we trust for a candidate header.
+MOD_MAP_CAPACITY_LIMIT = 32
+
+# Mirror of the C-side _Static_assert in mod_loader_registry.c — keep these in sync.
+assert ENTRY_SIZE == 132, "ENTRY_SIZE drifted from mod_record (must be 132)"
+ELF_MAGIC = b"\x7fELF"
+
+
+def _is_plausible_addr(addr: int) -> bool:
+    """
+    Coarse sanity filter for ESP32 runtime addresses. Module sections live in
+    the IRAM/IROM bus window (.text/.rodata via flash mmap) or in DRAM
+    (.data/.bss on heap). Anything outside these ranges means we hit a stray
+    'MODM' byte sequence somewhere else in the dump.
+    """
+    if addr == 0:
+        return True  # unused slots are zero
+    return 0x3F000000 <= addr < 0x60000000
+
+
+def _decode_entry(blob: bytes, offset: int) -> dict | None:
+    raw_name = blob[offset : offset + MOD_MAP_NAME_LEN]
+    name = raw_name.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+    if not name or any(ord(c) < 0x20 or ord(c) > 0x7E for c in name):
+        return None
+
+    sha1_bytes = blob[
+        offset + MOD_MAP_NAME_LEN : offset + MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN
+    ]
+    sha1_hex = sha1_bytes.hex()
+
+    sec_base = offset + MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN
+    out = {"name": name, "sha1": sha1_hex}
+    for i, sec_name in enumerate(("text", "data", "bss", "rodata")):
+        addr, v_addr, size = struct.unpack_from(
+            "<III", blob, sec_base + i * SECTION_SIZE
+        )
+        # A committed module's .text always maps into the IRAM/IROM window and
+        # is never 0; .text == 0 means the slot was acquired but not yet
+        # committed (mid-load) or was released, so skip it.
+        if sec_name == "text" and addr == 0:
+            return None
+        if not _is_plausible_addr(addr):
+            return None
+        out[f"{sec_name}_addr"] = f"0x{addr:08x}"
+        out[f"{sec_name}_vaddr"] = f"0x{v_addr:08x}"
+        out[f"{sec_name}_size"] = size
+    return out
+
+
+def _decode_registry(blob: bytes, offset: int) -> list[dict] | None:
+    """
+    Try to decode a registry header at `offset`. Returns the list of decoded
+    occupied entries (possibly empty), or None if the candidate fails
+    validation. The header self-describes its slot capacity; the array is
+    sparse, so empty/uncommitted/corrupt slots are skipped individually rather
+    than failing the whole registry.
+    """
+    if offset + REGISTRY_HEADER_SIZE > len(blob):
+        return None
+    capacity = blob[offset + 4]
+    if capacity < 1 or capacity > MOD_MAP_CAPACITY_LIMIT:
+        return None
+    if offset + REGISTRY_HEADER_SIZE + capacity * ENTRY_SIZE > len(blob):
+        return None
+    entries: list[dict] = []
+    for i in range(capacity):
+        entry_offset = offset + REGISTRY_HEADER_SIZE + i * ENTRY_SIZE
+        decoded = _decode_entry(blob, entry_offset)
+        if decoded is not None:
+            entries.append(decoded)
+    return entries
+
+
+def parse_module_map_from_coredump(core_path: str, verbose: bool = False) -> list[dict]:
+    """
+    Read the on-device module map out of an ELF-format core dump.
+
+    The coredump is always an ELF (CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y is
+    the default). The .dram2.coredump section is captured as part of a
+    PT_LOAD program header; we search the MODM magic only inside those
+    segments to avoid false positives in ELF metadata or other regions.
+
+    When the file was read raw from flash, a small chip-side header may
+    precede the ELF; we skip past it by locating the first ELF magic.
+    """
+    raw = Path(core_path).read_bytes()
+    elf_offset = raw.find(ELF_MAGIC)
+    if elf_offset < 0:
+        raise ValueError(
+            f"{core_path}: no ELF header found (is this an ESP-IDF coredump?)"
+        )
+
+    if verbose:
+        print(
+            f"DEBUG: coredump bytes={len(raw)} elf_offset=0x{elf_offset:x}",
+            file=sys.stderr,
+        )
+
+    elf_bytes = raw[elf_offset:]
+    needle = struct.pack("<I", MOD_MAP_MAGIC)
+    modules: list[dict] = []
+    seen_segments = 0
+    load_segments = 0
+    candidate_hits = 0
+    decoded_entries = 0
+
+    with ELFFile(io.BytesIO(elf_bytes)) as elf:
+        for segment in elf.iter_segments():
+            if segment.header.p_type != "PT_LOAD":
+                continue
+            load_segments += 1
+            data = segment.data()
+            pos = 0
+            while True:
+                pos = data.find(needle, pos)
+                if pos < 0:
+                    break
+                candidate_hits += 1
+                entries = _decode_registry(data, pos)
+                if entries is None:
+                    pos += 1
+                    continue
+                modules.extend(entries)
+                decoded_entries += len(entries)
+                seen_segments += 1
+                capacity = data[pos + 4]
+                pos += REGISTRY_HEADER_SIZE + capacity * ENTRY_SIZE
+
+    if verbose:
+        print(
+            "DEBUG: "
+            f"pt_load_segments={load_segments} "
+            f"modm_hits={candidate_hits} "
+            f"valid_registries={seen_segments} "
+            f"decoded_entries={decoded_entries}",
+            file=sys.stderr,
+        )
+
+    if seen_segments > 1:
+        print(
+            f"NOTE: found {seen_segments} module-map candidates in coredump; "
+            "merged all entries.",
+            file=sys.stderr,
+        )
+    return modules
+
+
+def parse_elf_map_arg(spec: str) -> tuple[str, str]:
+    """Parse 'name=path' into (name, path)."""
+    if "=" not in spec:
+        raise ValueError(f"--module-elf must be 'name=path' (got: {spec!r})")
+    name, path = spec.split("=", 1)
+    return name, path
+
+
+def generate_gdbinit(modules: list[dict], output_path: str):
+    """Generate a GDB init file with add-symbol-file commands."""
+    with open(output_path, "w") as f:
+        f.write("# Auto-generated by decode_module_coredump.py\n")
+        f.write("# Module symbol loading commands\n\n")
+        for mod in modules:
+            elf = mod["elf"]
+            # Path written into the add-symbol-file line. Defaults to the path
+            # we read below; callers (e.g. the download packager) can set
+            # 'elf_display' to a relative path that is valid where gdb runs.
+            elf_display = mod.get("elf_display", elf)
+            # Parse addresses (may be int or hex string)
+            text_runtime = int(mod["text_addr"], 16) if isinstance(mod["text_addr"], str) and mod["text_addr"].startswith("0x") else int(mod["text_addr"])
+            data = int(mod["data_addr"], 16) if isinstance(mod["data_addr"], str) and mod["data_addr"].startswith("0x") else int(mod["data_addr"])
+            bss = int(mod["bss_addr"], 16) if isinstance(mod["bss_addr"], str) and mod["bss_addr"].startswith("0x") else int(mod["bss_addr"])
+            rodata = int(mod["rodata_addr"], 16) if isinstance(mod["rodata_addr"], str) and mod["rodata_addr"].startswith("0x") else int(mod["rodata_addr"])
+
+            # `add-symbol-file FILE <addr>` expects <addr> to be the *runtime*
+            # address of the .text section; GDB computes the per-section slide
+            # itself as (addr - the ELF's .text sh_addr). text_runtime already IS
+            # that runtime address, so pass it as-is. Do NOT pre-subtract the
+            # ELF's .text vaddr: when sh_addr != 0 (ESP ELF modules link .text at
+            # a small non-zero vaddr) that double-counts the vaddr and shifts
+            # every symbol, mislabeling frames to the next function up.
+            f.write(f"echo \\n=== Loading module '{mod['name']}' symbols ===\\n\n")
+            f.write(
+                f"add-symbol-file {elf_display} {hex(text_runtime)} "
+                f"-s .data {hex(data)} "
+                f"-s .bss {hex(bss)} "
+                f"-s .rodata {hex(rodata)}\n"
+            )
+        f.write("\necho \\n=== Module symbols loaded. Use 'bt' or 'info threads' ===\\n\n")
+
+
+def run_espcoredump(args, modules: list[dict], operation: str):
+    """Symbolicate a coredump, loading any module symbols via gdbinit.
+
+    The whole job is: generate a gdbinit with add-symbol-file lines for the
+    modules, then hand it to the esp-coredump console script through its native
+    --extra-gdbinit-file (honored by esp_coredump's CLI; see coredump.py). The
+    stored coredump is a raw partition image, so -t raw parses it directly — no
+    normalization needed.
+    """
+    gdbinit_path = None
+    try:
+        cmd = ["esp-coredump", operation, "-t", args.core_format, "-c", args.core]
+        if modules:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".gdbinit", delete=False, prefix="mod_"
+            ) as f:
+                gdbinit_path = f.name
+            generate_gdbinit(modules, gdbinit_path)
+            cmd += ["--extra-gdbinit-file", gdbinit_path]
+            print(f"Generated GDB init: {gdbinit_path}", file=sys.stderr)
+        if args.gdb:
+            cmd += ["--gdb", args.gdb]
+        cmd.append(args.prog)
+        print(f"Running: {' '.join(cmd)}", file=sys.stderr)
+        subprocess.run(cmd)
+    finally:
+        # Keep the gdbinit for interactive sessions so the user can re-source it;
+        # otherwise clean it up.
+        if gdbinit_path:
+            if operation == "dbg_corefile":
+                print(f"\nGDB init file preserved at: {gdbinit_path}", file=sys.stderr)
+            else:
+                os.unlink(gdbinit_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Decode ESP32 core dumps with module symbols",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    parser.add_argument(
+        "operation",
+        choices=["dbg", "info"],
+        help="'dbg' for interactive GDB, 'info' for backtrace summary",
+    )
+    parser.add_argument(
+        "--core", "-c", required=True, help="Path to core dump file (raw binary)"
+    )
+    parser.add_argument(
+        "--core-format",
+        "-t",
+        choices=["auto", "b64", "elf", "raw"],
+        default="raw",
+        dest="core_format",
+        help="Core dump format passed to esp-coredump (default: raw)",
+    )
+    parser.add_argument(
+        "--prog", "-p", required=True, help="Path to host application ELF"
+    )
+    parser.add_argument(
+        "--module-elf",
+        action="append",
+        default=[],
+        help=(
+            "Module ELF mapping 'name=path' (repeatable). Used to resolve "
+            "names found in the on-device module map embedded in the coredump."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print extraction diagnostics (ELF offset, PT_LOAD scans, MODM hits).",
+    )
+    parser.add_argument(
+        "--gdb",
+        help="Path to GDB executable passed to espcoredump.py (for example /opt/homebrew/bin/gdb).",
+    )
+
+    args = parser.parse_args()
+
+    elf_map: dict[str, str] = {}
+    for spec in args.module_elf:
+        name, path = parse_elf_map_arg(spec)
+        elf_map[name] = path
+
+    modules: list[dict] = []
+    for m in parse_module_map_from_coredump(args.core, args.verbose):
+        elf = elf_map.get(m["name"])
+        if not elf:
+            print(
+                f"WARNING: coredump map references module '{m['name']}' but no "
+                f"--module-elf {m['name']}=<path> was supplied; skipping.",
+                file=sys.stderr,
+            )
+            continue
+        m["elf"] = elf
+        modules.append(m)
+        print(
+            f"Extracted module '{m['name']}' (sha1={m['sha1']}) from coredump map: "
+            f"text={m['text_addr']} data={m['data_addr']} "
+            f"bss={m['bss_addr']} rodata={m['rodata_addr']}",
+            file=sys.stderr,
+        )
+
+    if not modules:
+        print(
+            "WARNING: No modules resolved. Running without module symbols.",
+            file=sys.stderr,
+        )
+
+    operation = "dbg_corefile" if args.operation == "dbg" else "info_corefile"
+    run_espcoredump(args, modules, operation)
+
+
+if __name__ == "__main__":
+    main()

--- a/esp-crash-server/requirements.txt
+++ b/esp-crash-server/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 psycopg2
 esp-coredump
+pyelftools
 gunicorn
 flask_dance
 SQLAlchemy

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -16,6 +16,7 @@ import requests
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 import logging
+import decode_module_coredump as mod_decoder
 
 # Configure logging
 logging.basicConfig(
@@ -236,6 +237,34 @@ def list_projects():
     """Render the landing page listing all projects."""
     return render_template('index.html')
 
+def _module_names_for_dump(crash_dmp):
+    """Best-effort list of module names referenced by a crash dump.
+
+    Used to render the "Modules" tags in the crash list. Parses the on-device
+    module map straight from the dump (independent of whether the crash has
+    been symbolicated yet). Never raises — returns [] on any problem.
+    """
+    if not crash_dmp:
+        return []
+    try:
+        try:
+            decompressed = bz2.decompress(crash_dmp)
+        except IOError:
+            decompressed = crash_dmp
+        dmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
+                df.write(decompressed)
+                dmp_path = df.name
+            entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
+        finally:
+            if dmp_path:
+                os.unlink(dmp_path)
+        return [e["name"] for e in entries]
+    except Exception:
+        return []
+
+
 @app.route('/projects/<project_name>')
 @login_required
 def list_project_crashes(project_name):
@@ -261,6 +290,7 @@ def list_project_crashes(project_name):
             crash.project_name,
             crash.device_id,
             crash.project_ver,
+            crash.module_names,
             array_agg(elf_file.elf_file_id) FILTER (WHERE elf_file.elf_file_id IS NOT NULL) as elf_file_id,
             array_agg(elf_file.project_alias) as project_alias,
             device.ext_device_id,
@@ -294,6 +324,8 @@ def list_project_crashes(project_name):
 
 
 
+    # crash.module_names is populated at cron processing time, so no per-row
+    # coredump parsing happens here.
     return render_template('project.html', crashes = crashes, project_name = project_name, search = search or "", limit = limit, offset = offset, full_count = crashes[0]["full_count"] if len(crashes) > 0 else 0)
 
 @app.route('/crash')
@@ -850,7 +882,38 @@ def show_project_crash(project_name, crash_id):
     # Fetch all elf image data from database that matches this project and version
     elf_images = ldb().get_data("SELECT elf_file_id, date, project_name, project_ver, file_size, project_alias FROM elf_file WHERE project_name = %s AND project_ver = %s ORDER BY date DESC", (crash["project_name"], crash["project_ver"], ))
 
-    return render_template('crash.html', crash = crash, elf_images = elf_images, dump = crash["dump"])
+    # Module map (best-effort; only used to populate the UI block).
+    modules_for_ui = []
+    try:
+        try:
+            decompressed_dmp = bz2.decompress(crash["crash_dmp"])
+        except IOError:
+            decompressed_dmp = crash["crash_dmp"]
+        dmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
+                df.write(decompressed_dmp)
+                dmp_path = df.name
+            entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
+        finally:
+            if dmp_path:
+                os.unlink(dmp_path)
+        for e in entries:
+            sha1 = e.get("sha1", "")
+            row = ldb().get_data(
+                "SELECT module_elf_id FROM module_elf WHERE app_sha1 = %s LIMIT 1",
+                (sha1,),
+            )
+            modules_for_ui.append({
+                "name": e["name"],
+                "sha1_short": sha1[:8],
+                "sha1_full": sha1,
+                "available": bool(row),
+            })
+    except Exception as ex:
+        app.logger.warning(f"Module map UI parse failed for crash {crash_id}: {ex}")
+
+    return render_template('crash.html', crash = crash, elf_images = elf_images, dump = crash["dump"], modules = modules_for_ui)
 
 
 @app.route('/projects/<project_name>/<crash_id>/refresh')
@@ -876,6 +939,62 @@ def refresh_crash(project_name, crash_id):
     conn.commit()
 
     return redirect(url_for('show_project_crash', project_name=project_name, crash_id=crash_id))
+
+
+def _resolve_modules_for_dump(db, dump_bytes):
+    """
+    Parse the on-device module map from `dump_bytes`. For every entry, look up
+    the matching debug ELF in module_elf by app_sha1.
+
+    Returns:
+      (resolved_modules, status_lines)
+        resolved_modules: list[dict] enriched with 'elf' = filesystem path to
+                          a temp file containing the uncompressed debug ELF.
+        status_lines: list[str] human-readable annotations, including
+                      "module X (sha1 abcd...): symbols not available" for
+                      missing entries.
+    """
+    import io as _io
+    import tempfile as _tempfile
+
+    # Write dump to a NamedTemporaryFile so the existing parser can read it.
+    dmp_path = None
+    try:
+        with _tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
+            df.write(dump_bytes)
+            dmp_path = df.name
+        entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
+    except Exception as e:
+        return [], [f"# module map parse error: {e}"]
+    finally:
+        if dmp_path:
+            os.unlink(dmp_path)
+
+    resolved = []
+    status = []
+    for entry in entries:
+        sha1 = entry.get("sha1", "")
+        rows = db.get_data(
+            "SELECT elf_file FROM module_elf WHERE app_sha1 = %s LIMIT 1",
+            (sha1,),
+        )
+        if not rows:
+            status.append(
+                f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols not available"
+            )
+            continue
+        try:
+            blob = bz2.decompress(rows[0]["elf_file"])
+        except IOError:
+            blob = rows[0]["elf_file"]
+        with _tempfile.NamedTemporaryFile(suffix=".elf", delete=False, prefix="mod_") as ef:
+            ef.write(blob)
+            entry["elf"] = ef.name
+        resolved.append(entry)
+        status.append(
+            f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols loaded"
+        )
+    return resolved, status
 
 
 @app.route('/cron')
@@ -933,20 +1052,59 @@ def cron():
             elf.write(decompressed_elf_file)
             elf.close()
 
-            # Run esp-coredump to get crash dump info
-            p = subprocess.run(["esp-coredump", "--chip", "esp32s3", "info_corefile", "-t", "raw", "-c", dmp.name, elf.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            d = p.stdout + p.stderr
-            dump += d.decode("utf-8")
+            # Resolve modules referenced by the dump (best-effort; missing
+            # modules are annotated but never block processing).
+            modules, mod_status = _resolve_modules_for_dump(ldb(), decompressed_crash_dmp)
+
+            for line in mod_status:
+                dump += line + "\n"
+
+            gdbinit_path = None
+            try:
+                # The stored dump is a raw coredump-partition image, so -t raw
+                # parses it directly. When modules are referenced, generate a
+                # gdbinit with their add-symbol-file lines and hand it to
+                # esp-coredump's native --extra-gdbinit-file. The chip is
+                # auto-detected from the self-describing raw image.
+                cmd = ["esp-coredump", "info_corefile", "-t", "raw", "-c", dmp.name]
+                if modules:
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".gdbinit", delete=False, prefix="mod_"
+                    ) as gf:
+                        gdbinit_path = gf.name
+                    mod_decoder.generate_gdbinit(modules, gdbinit_path)
+                    cmd += ["--extra-gdbinit-file", gdbinit_path]
+                cmd.append(elf.name)
+                p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                dump += (p.stdout + p.stderr).decode("utf-8")
+            finally:
+                # Clean up temp module ELF files and the generated gdbinit.
+                for m in modules:
+                    try:
+                        os.remove(m["elf"])
+                    except OSError:
+                        pass
+                if gdbinit_path:
+                    try:
+                        os.remove(gdbinit_path)
+                    except OSError:
+                        pass
 
             # Delete temporary files
             os.unlink(dmp.name)
             os.unlink(elf.name)
 
-        # Update the dump field in the database with the crash dump info
-
-        c.execute("UPDATE crash SET dump = %s WHERE crash_id = %s", (dump, crash["crash_id"],))
+        # Update the dump field in the database with the crash dump info.
+        # Also persist the referenced module names now (at processing time) so the
+        # crash-list view can render its "Modules" tags without parsing every
+        # coredump on each page load.
+        module_names = _module_names_for_dump(crash["crash_dmp"])
+        c.execute(
+            "UPDATE crash SET dump = %s, module_names = %s WHERE crash_id = %s",
+            (dump, module_names, crash["crash_id"]),
+        )
         conn.commit()
-        app.logger.info("Updated crash {}".format(crash["crash_id"]))
+        app.logger.info("Updated crash {} (modules: {})".format(crash["crash_id"], module_names))
 
         # Send webhooks
         project_name = crash["project_name"]
@@ -1202,33 +1360,82 @@ def download_crash(crash_id):
         zip_file.write(dmp.name,  arcname="crash_{}/crash_{}.dmp".format(crash_id, crash_id))
         os.unlink(dmp.name)
 
-        for elf_image in elf_images:
-            # Create temporary files to store crash and elf data
-            elf = tempfile.NamedTemporaryFile(delete=False)
+        # Resolve any dynamically-loaded modules referenced by the dump so the
+        # package can ship their debug ELFs and a ready-to-use gdbinit. Each
+        # resolved entry's debug ELF is written to a temp file (m["elf"]); clean
+        # those up in the finally below.
+        resolved, mod_status = _resolve_modules_for_dump(ldb(), decompressed_crash_dmp)
+        try:
+            if resolved:
+                # Ship each module's debug ELF and remember the relative path the
+                # gdbinit should reference (valid once the script cd's into the
+                # package dir).
+                for m in resolved:
+                    safe = re.sub(r'[^A-Za-z0-9._-]', '_', m["name"])
+                    zip_file.write(m["elf"], arcname="crash_{}/modules/{}.elf".format(crash_id, safe))
+                    m["elf_display"] = "modules/{}.elf".format(safe)
+                # Pre-generate the gdbinit: reads each m["elf"] for the load base,
+                # emits the relative m["elf_display"] paths.
+                gi = tempfile.NamedTemporaryFile(mode="w", suffix=".gdbinit", delete=False)
+                gi.close()
+                mod_decoder.generate_gdbinit(resolved, gi.name)
+                zip_file.write(gi.name, arcname="crash_{}/module_symbols.gdbinit".format(crash_id))
+                os.unlink(gi.name)
+                # Note any referenced modules whose symbols were not uploaded.
+                missing = [s for s in mod_status if "symbols not available" in s]
+                if missing:
+                    zip_file.writestr(
+                        "crash_{}/MODULES_README.txt".format(crash_id),
+                        "Modules referenced by this crash with no uploaded symbols "
+                        "(their frames will not be symbolicated):\n\n" + "\n".join(missing) + "\n",
+                    )
 
-            try:
-                decompressed_elf_file = bz2.decompress(elf_image["elf_file"])
-            except IOError:
-                decompressed_elf_file = elf_image["elf_file"]
+            for elf_image in elf_images:
+                # Create temporary files to store crash and elf data
+                elf = tempfile.NamedTemporaryFile(delete=False)
 
-            # Write decompressed data to temporary files
-            elf.write(decompressed_elf_file)
-            elf.close()
+                try:
+                    decompressed_elf_file = bz2.decompress(elf_image["elf_file"])
+                except IOError:
+                    decompressed_elf_file = elf_image["elf_file"]
 
-            # Add files to zip
-            zip_file.write(elf.name, arcname="crash_{}/elf_{}.elf".format(crash_id, elf_image["elf_file_id"]))
+                # Write decompressed data to temporary files
+                elf.write(decompressed_elf_file)
+                elf.close()
 
-            os.unlink(elf.name)
+                # Add files to zip
+                zip_file.write(elf.name, arcname="crash_{}/elf_{}.elf".format(crash_id, elf_image["elf_file_id"]))
 
-            script = tempfile.NamedTemporaryFile(delete=False)
-            script.write("#!/bin/bash\n".encode())
-            script.write(". $ESP_IDF/export.sh\n".encode())
-            script.write("exec esp-coredump dbg_corefile -t raw --core {} {}\n".format("crash_{}.dmp".format(crash_id), "elf_{}.elf".format(elf_image["elf_file_id"])).encode())
-            script.close()
-            zip_file.write(script.name, arcname="crash_{}/elf_{}.sh".format(crash_id, elf_image["elf_file_id"]))
+                os.unlink(elf.name)
 
+                core_arc = "crash_{}.dmp".format(crash_id)
+                elf_arc = "elf_{}.elf".format(elf_image["elf_file_id"])
+                lines = ["#!/bin/bash"]
+                if resolved:
+                    lines.append("# Launches esp-coredump with module symbols pre-loaded.")
+                # cd into the package dir so the relative .dmp/.elf/gdbinit paths resolve.
+                lines.append('cd "$(dirname "$0")"')
+                lines.append(". $ESP_IDF/export.sh")
+                if resolved:
+                    lines.append(
+                        "exec esp-coredump dbg_corefile -t raw --core {} \\\n"
+                        "    --extra-gdbinit-file module_symbols.gdbinit {}".format(core_arc, elf_arc)
+                    )
+                else:
+                    lines.append("exec esp-coredump dbg_corefile -t raw --core {} {}".format(core_arc, elf_arc))
 
-
+                script = tempfile.NamedTemporaryFile(delete=False)
+                script.write(("\n".join(lines) + "\n").encode())
+                script.close()
+                zip_file.write(script.name, arcname="crash_{}/elf_{}.sh".format(crash_id, elf_image["elf_file_id"]))
+                os.unlink(script.name)
+        finally:
+            # Clean up the temp module debug ELFs written by _resolve_modules_for_dump.
+            for m in resolved:
+                try:
+                    os.remove(m["elf"])
+                except OSError:
+                    pass
 
     # Send zip file
     status = send_file(zipf.name, mimetype='application/zip', as_attachment=True, download_name="crash_{}.zip".format(crash_id))
@@ -1470,6 +1677,48 @@ def upload_elf():
 
     # Return a success message
     return "OK", 200
+
+@app.route('/upload_module_elf', methods=['POST'])
+def upload_module_elf():
+    """Upload a module debug ELF, identified by SHA1 of the wire .app bytes."""
+    if 'file' not in request.files:
+        return "No file part", 400
+    file = request.files['file']
+    if file.filename == '':
+        return "No selected file", 400
+
+    name = request.args.get('name') or request.form.get('name')
+    app_sha1 = request.args.get('app_sha1') or request.form.get('app_sha1')
+
+    if not name:
+        return "Missing name", 400
+    if not app_sha1 or len(app_sha1) != 40 or not all(c in '0123456789abcdefABCDEF' for c in app_sha1):
+        return "Missing or malformed app_sha1 (expect 40 hex chars)", 400
+    app_sha1 = app_sha1.lower()
+
+    raw = file.read()
+    # Store compressed; record the uncompressed size. Accept either a raw ELF
+    # or an already-bz2-compressed upload (decompress only once to detect).
+    try:
+        uncompressed_size = len(bz2.decompress(raw))
+        compressed = raw
+    except IOError:
+        compressed = bz2.compress(raw)
+        uncompressed_size = len(raw)
+
+    db = ldb()
+    cur = db.cursor()
+    cur.execute(
+        """
+        INSERT INTO module_elf (date, name, app_sha1, elf_file, file_size)
+        VALUES (NOW(), %s, %s, %s, %s)
+        ON CONFLICT (app_sha1) DO NOTHING
+        """,
+        (name, app_sha1, psycopg2.Binary(compressed), uncompressed_size),
+    )
+    db.commit()
+    app.logger.info(f"Stored module_elf name={name} app_sha1={app_sha1} size={uncompressed_size}")
+    return "OK\n", 200
 
 @app.route('/projects/<project_name>/slack/test')
 @login_required

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -61,6 +61,33 @@
     {% endfor %}
     </div>
 </div>
+{% if modules %}
+<div class="w-5/6 mt-4">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900">Modules referenced by this crash</h3>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {% for m in modules %}
+        <div class="p-4 bg-white border border-gray-200 rounded-lg shadow"
+             style="border-left: 4px solid {{ '#22c55e' if m.available else '#ef4444' }};">
+            <div class="flex items-center justify-between">
+                <span class="font-mono font-bold text-slate-900 truncate" title="{{ m.name }}">{{ m.name }}</span>
+                {% if m.available %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 whitespace-nowrap">
+                    <span class="mr-1">&#9679;</span>symbols available
+                </span>
+                {% else %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 whitespace-nowrap">
+                    <span class="mr-1">&#9679;</span>symbols not uploaded
+                </span>
+                {% endif %}
+            </div>
+            <div class="mt-2 text-xs text-gray-500 font-mono break-all">
+                sha1 {{ m.sha1_full }}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
 <div
     class="w-5/6 h-5/6 p-8 m-0 border border-gray-200 rounded-lg shadow mt-4 whitespace-pre bg-black text-sm text-white overflow-scroll font-mono">
 

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -43,6 +43,7 @@ endblock %}
                 {% endif %}
                 <th scope="col" class="px-6 py-3">Project Version</th>
                 <th scope="col" class="px-6 py-3">Device Id</th>
+                <th scope="col" class="px-6 py-3">Modules</th>
                 <th scope="col" class="px-6 py-3"></th>
             </tr>
         </thead>
@@ -74,6 +75,19 @@ endblock %}
                     <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, search=crash.ext_device_id) }}">{{ crash.ext_device_id }}</a>
                 </td>
                 {% endif %}
+                <td class="px-6 py-4">
+                    {% if crash.module_names %}
+                    <div class="flex flex-wrap gap-1">
+                        {% for mod in crash.module_names %}
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium font-mono bg-indigo-100 text-indigo-800" title="Module referenced by this crash">
+                            <span class="mr-1 text-indigo-500">&#9679;</span>{{ mod }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% else %}
+                    <span class="text-gray-300">&mdash;</span>
+                    {% endif %}
+                </td>
                 <td class="px-6 py-4">
                     <a href="{{ url_for('delete_crash', project_name=crash.project_name, crash_id=crash.crash_id) }}" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Delete</a>
                     <a href="{{ url_for('show_device', device_id=crash.device_id) }}" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Device</a>


### PR DESCRIPTION
- add support for uploading module elf files through a new dedicated endpoint `/upload_module_elf` takes a sha1 as the key to match against coredumps with loaded modules with such a checksum.
- add support to extract module map section info from uploaded coredumps using a dedicated section recognized using a MODM magic code
- appends espcoredump with the generated gdbinit files that contain the `add-symbol-file` command to add the module elf files to the gdb session.

screenshots:
<img width="1377" height="404" alt="image" src="https://github.com/user-attachments/assets/8dfc4bb2-252a-4b8f-93ce-038d3e5726d2" />

---

<img width="1377" height="733" alt="image" src="https://github.com/user-attachments/assets/453dd5e6-aeb0-4d9c-9216-8aed75b68a7c" />

