### PR TITLE
Feat/device url template

### DIFF
--- a/esp-crash-server/Dockerfile
+++ b/esp-crash-server/Dockerfile
@@ -3,9 +3,9 @@
 FROM python:3.12-slim-bookworm AS wheel-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    python3-dev \
+  build-essential \
+  libpq-dev \
+  python3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /setup
@@ -16,8 +16,8 @@ RUN python -m pip install --no-cache-dir --upgrade pip wheel \
 FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    libpq5 \
+  ca-certificates \
+  libpq5 \
   && rm -rf /var/lib/apt/lists/*
 
 # ESP tool versions pinned to IDF v5.5.4 tools.json manifest.
@@ -30,20 +30,20 @@ ARG TARGETARCH
 RUN set -eux \
   && apt-get update && apt-get install -y --no-install-recommends curl \
   && case "${TARGETARCH}" in \
-       amd64) \
-         GDB_URL="https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v${GDB_VERSION}/xtensa-esp-elf-gdb-${GDB_VERSION}-x86_64-linux-gnu.tar.gz" \
-         GDB_SHA256="16d05c9104ff84529ac3799abb04d5666c193131ab461f153040721728b48730" ;; \
-       arm64) \
-         GDB_URL="https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v${GDB_VERSION}/xtensa-esp-elf-gdb-${GDB_VERSION}-aarch64-linux-gnu.tar.gz" \
-         GDB_SHA256="ecbd53ba28cf24301be8260249bfcfb60567f938f4402797617c8a0fc170dc7d" ;; \
-       *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
-     esac \
+  amd64) \
+  GDB_URL="https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v${GDB_VERSION}/xtensa-esp-elf-gdb-${GDB_VERSION}-x86_64-linux-gnu.tar.gz" \
+  GDB_SHA256="16d05c9104ff84529ac3799abb04d5666c193131ab461f153040721728b48730" ;; \
+  arm64) \
+  GDB_URL="https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v${GDB_VERSION}/xtensa-esp-elf-gdb-${GDB_VERSION}-aarch64-linux-gnu.tar.gz" \
+  GDB_SHA256="ecbd53ba28cf24301be8260249bfcfb60567f938f4402797617c8a0fc170dc7d" ;; \
+  *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+  esac \
   && ROM_ELFS_URL="https://github.com/espressif/esp-rom-elfs/releases/download/${ROM_ELFS_VERSION}/esp-rom-elfs-${ROM_ELFS_VERSION}.tar.gz" \
   && ROM_ELFS_SHA256="921f000164a421c7628fbfee55b173384aafaa51883adc65cd27bf9b0af9e9a9" \
   && mkdir -p \
-       /opt/esp/tools/xtensa-esp-elf-gdb/${GDB_VERSION} \
-       /opt/esp/tools/esp-rom-elfs/${ROM_ELFS_VERSION} \
-       /opt/esp/idf/tools/idf_py_actions \
+  /opt/esp/tools/xtensa-esp-elf-gdb/${GDB_VERSION} \
+  /opt/esp/tools/esp-rom-elfs/${ROM_ELFS_VERSION} \
+  /opt/esp/idf/tools/idf_py_actions \
   && curl -fsSL "${GDB_URL}" -o /tmp/gdb.tar.gz \
   && echo "${GDB_SHA256}  /tmp/gdb.tar.gz" | sha256sum -c - \
   && tar xzf /tmp/gdb.tar.gz -C /opt/esp/tools/xtensa-esp-elf-gdb/${GDB_VERSION}/ \
@@ -51,7 +51,7 @@ RUN set -eux \
   && echo "${ROM_ELFS_SHA256}  /tmp/rom-elfs.tar.gz" | sha256sum -c - \
   && tar xzf /tmp/rom-elfs.tar.gz -C /opt/esp/tools/esp-rom-elfs/${ROM_ELFS_VERSION}/ \
   && curl -fsSL "https://raw.githubusercontent.com/espressif/esp-idf/${IDF_VERSION}/tools/idf_py_actions/roms.json" \
-       -o /opt/esp/idf/tools/idf_py_actions/roms.json \
+  -o /opt/esp/idf/tools/idf_py_actions/roms.json \
   && rm -f /tmp/gdb.tar.gz /tmp/rom-elfs.tar.gz \
   && apt-get purge -y --auto-remove curl \
   && rm -rf /var/lib/apt/lists/*
@@ -70,6 +70,7 @@ RUN python -m pip install --no-cache-dir --no-index --find-links=/wheels -r requ
 WORKDIR /code
 COPY server.py .
 COPY decode_module_coredump.py /code
+COPY device_url.py .
 COPY templates/ templates/
 
 ENV FLASK_APP=server.py

--- a/esp-crash-server/db_schema.sql
+++ b/esp-crash-server/db_schema.sql
@@ -63,6 +63,11 @@ CREATE TABLE IF NOT EXISTS project_slack_integrations (
     github_user TEXT
 );
 
+CREATE TABLE IF NOT EXISTS project_settings (
+    project_name TEXT PRIMARY KEY,
+    device_url_template TEXT
+);
+
 CREATE INDEX idx_elf_file_project ON elf_file (project_name, project_ver);
 CREATE INDEX idx_elf_file_project_name ON elf_file (project_name);
 CREATE INDEX idx_crash_project_name_ver ON crash (project_name, project_ver);

--- a/esp-crash-server/device_url.py
+++ b/esp-crash-server/device_url.py
@@ -1,0 +1,31 @@
+"""Pure helpers for the per-project device-id URL template.
+
+Kept separate from server.py so the logic can be unit-tested without importing
+the Flask app and its OAuth/Slack setup.
+"""
+import urllib.parse
+
+# The single supported placeholder token, substituted with the (URL-encoded)
+# device identifier the device reported (its burn-in QR code, or MAC fallback).
+DEVICE_ID_PLACEHOLDER = "{device_id}"
+
+
+def device_url_template_is_valid(template):
+    """A blank template is valid (it clears the setting). A non-blank template
+    must contain the {device_id} placeholder, otherwise it can never produce a
+    working link."""
+    if not template or not template.strip():
+        return True
+    return DEVICE_ID_PLACEHOLDER in template
+
+
+def resolve_device_url(template, device_id):
+    """Substitute the URL-encoded device id into the template.
+
+    Returns None when there is no usable template (blank, or missing the
+    placeholder) so callers can simply skip rendering the link.
+    """
+    if not template or DEVICE_ID_PLACEHOLDER not in template:
+        return None
+    encoded = urllib.parse.quote(device_id or "", safe="")
+    return template.replace(DEVICE_ID_PLACEHOLDER, encoded)

--- a/esp-crash-server/device_url.py
+++ b/esp-crash-server/device_url.py
@@ -9,23 +9,36 @@ import urllib.parse
 # device identifier the device reported (its burn-in QR code, or MAC fallback).
 DEVICE_ID_PLACEHOLDER = "{device_id}"
 
+_ALLOWED_SCHEMES = ("http://", "https://")
+
+
+def _has_safe_scheme(url):
+    """Return True iff *url* starts with http:// or https:// (case-insensitive)."""
+    lower = url.strip().lower()
+    return any(lower.startswith(scheme) for scheme in _ALLOWED_SCHEMES)
+
 
 def device_url_template_is_valid(template):
     """A blank template is valid (it clears the setting). A non-blank template
-    must contain the {device_id} placeholder, otherwise it can never produce a
-    working link."""
+    must contain the {device_id} placeholder AND start with http:// or https://
+    (case-insensitive). Any other scheme is rejected to prevent stored-XSS via
+    javascript: or similar URIs."""
     if not template or not template.strip():
         return True
-    return DEVICE_ID_PLACEHOLDER in template
+    return DEVICE_ID_PLACEHOLDER in template and _has_safe_scheme(template)
 
 
 def resolve_device_url(template, device_id):
     """Substitute the URL-encoded device id into the template.
 
-    Returns None when there is no usable template (blank, or missing the
-    placeholder) so callers can simply skip rendering the link.
+    Returns None when there is no usable template (blank, missing the
+    placeholder, or a non-http(s) scheme) so callers can simply skip rendering
+    the link. The scheme check neutralises any already-stored bad template at
+    render time, acting as a defence-in-depth guard against stored XSS.
     """
     if not template or DEVICE_ID_PLACEHOLDER not in template:
+        return None
+    if not _has_safe_scheme(template):
         return None
     encoded = urllib.parse.quote(device_id or "", safe="")
     return template.replace(DEVICE_ID_PLACEHOLDER, encoded)

--- a/esp-crash-server/project_settings_migration.sql
+++ b/esp-crash-server/project_settings_migration.sql
@@ -1,0 +1,7 @@
+-- Migration script to add per-project settings support.
+-- Run this against existing ESP-Crash installations (fresh installs get it from db_schema.sql).
+
+CREATE TABLE IF NOT EXISTS project_settings (
+    project_name TEXT PRIMARY KEY,
+    device_url_template TEXT
+);

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -912,13 +912,15 @@ def show_project_crash(project_name, crash_id):
     auth_where, auth_args = auth_clause("project_auth.github")
     crash = ldb().get_data("""
         SELECT
-            crash.crash_id, crash.date, crash.project_name, crash.device_id, crash.project_ver, crash.crash_dmp, device.ext_device_id, COALESCE(device.alias, '') as device_alias, crash.dump
+            crash.crash_id, crash.date, crash.project_name, crash.device_id, crash.project_ver, crash.crash_dmp, device.ext_device_id, COALESCE(device.alias, '') as device_alias, crash.dump, project_settings.device_url_template
         FROM
             crash
         JOIN
             project_auth USING (project_name)
         JOIN
             device USING (device_id)
+        LEFT JOIN
+            project_settings USING (project_name)
         WHERE
             crash_id = %s AND """ + auth_where + """
         ORDER BY

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -516,12 +516,20 @@ def project_settings(project_name):
         ORDER BY created_date DESC
     """, (project_name,))
 
+    settings_row = db.get_data(
+        "SELECT device_url_template FROM project_settings WHERE project_name = %s",
+        (project_name,))
+    device_url_template = settings_row[0]['device_url_template'] if settings_row else ''
+
     return render_template('project_settings.html',
                          project_name=project_name,
                          acls=acls,
                          webhooks=webhooks_list,
                          slack_integrations=slack_integrations,
-                         slack_client_id=app.config['SLACK_CLIENT_ID'])
+                         slack_client_id=app.config['SLACK_CLIENT_ID'],
+                         device_url_template=device_url_template or '',
+                         device_url_placeholder=DEVICE_ID_PLACEHOLDER,
+                         device_url_error=request.args.get('device_url_error'))
 
 @app.route('/projects/<project_name>/webhooks', methods=['GET', 'POST'])
 @login_required
@@ -576,6 +584,37 @@ def project_webhooks_admin(project_name):
         return redirect(url_for('project_settings', project_name=project_name))
 
     # GET request logic
+    return redirect(url_for('project_settings', project_name=project_name))
+
+@app.route('/projects/<project_name>/settings/device-url', methods=['POST'])
+@login_required
+def project_device_url_admin(project_name):
+    """Save (or clear) the per-project device-id URL template."""
+    db = ldb()
+    cur = db.cursor()
+
+    # Permission check: same gate as the rest of the project settings.
+    auth_where, auth_args = auth_clause("github")
+    auth_check = db.get_data("""
+        SELECT project_name FROM project_auth
+        WHERE project_name = %s AND """ + auth_where + """
+    """, (project_name,) + auth_args)
+    if not auth_check:
+        return "Forbidden: You do not have access to this project.", 403
+
+    template = (request.form.get('device_url_template') or '').strip()
+
+    # A non-blank template must contain the {device_id} placeholder; blank clears it.
+    if not device_url_template_is_valid(template):
+        return redirect(url_for('project_settings', project_name=project_name, device_url_error='1'))
+
+    cur.execute("""
+        INSERT INTO project_settings (project_name, device_url_template)
+        VALUES (%s, %s)
+        ON CONFLICT (project_name) DO UPDATE SET device_url_template = EXCLUDED.device_url_template
+    """, (project_name, template or None))
+    db.commit()
+
     return redirect(url_for('project_settings', project_name=project_name))
 
 @app.route('/projects/<project_name>/slack/auth')

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -2,6 +2,12 @@ import os
 import re
 import json
 
+from device_url import (
+    DEVICE_ID_PLACEHOLDER,
+    device_url_template_is_valid,
+    resolve_device_url,
+)
+
 from functools import wraps
 from flask import Flask, app, request, redirect, url_for, session, send_file, jsonify
 from flask_dance.contrib.github import make_github_blueprint, github
@@ -147,6 +153,7 @@ def render_template(template_name, **context):
 
 github_bp = make_github_blueprint()
 app.register_blueprint(github_bp, url_prefix="/login")
+app.jinja_env.filters['resolve_device_url'] = resolve_device_url
 def login_required(f):
     """Decorator to require GitHub authentication."""
     @wraps(f)

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -302,6 +302,7 @@ def list_project_crashes(project_name):
             array_agg(elf_file.project_alias) as project_alias,
             device.ext_device_id,
             device.alias,
+            project_settings.device_url_template,
             count(*) OVER() AS full_count
         FROM
             crash
@@ -311,6 +312,8 @@ def list_project_crashes(project_name):
             elf_file USING (project_name, project_ver)
         LEFT JOIN
             device USING (device_id)
+        LEFT JOIN
+            project_settings USING (project_name)
         WHERE
         """ + where_part + """
         GROUP BY
@@ -320,7 +323,8 @@ def list_project_crashes(project_name):
             crash.device_id,
             crash.project_ver,
             device.ext_device_id,
-            device.alias
+            device.alias,
+            project_settings.device_url_template
         ORDER BY
             crash.date DESC, crash.crash_id
         LIMIT

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -57,7 +57,7 @@
         <b><a href="{{ url_for('show_device', device_id=crash.device_id) }}">{{ crash.ext_device_id }}<br />{{ crash.device_alias}} </a></b>
         {% endif %}
         {% if device_ext_url %}
-        <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
+        <a href="{{ device_ext_url }}" target="_blank" rel="noopener noreferrer" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
             <svg aria-hidden="true" class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
             </svg>

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -49,11 +49,21 @@
     <span class="w-1/6 text-center">crash size<br /><b>{{ crash.crash_dmp|length }} bytes</b></span>
     <span class="w-1/6 text-center">date<br /><b>{{crash.date.strftime('%Y-%m-%d')}}<br />{{crash.date.strftime('%H:%M:%S')}}</b></span>
     <span class="w-1/6 text-center">project_name<br /><b>{{ crash.project_name }}</b></span>
-    {% if crash.alias %}
-    <span class="w-1/6 text-center">device_id<br /><b><a href="{{ url_for('show_device', device_id=crash.device_id) }}">{{ crash.alias }} ({{ crash.ext_device_id }})</a></b></span>
-    {% else %}
-    <span class="w-1/6 text-center">device_id<br /><b><a href="{{ url_for('show_device', device_id=crash.device_id) }}">{{ crash.ext_device_id }}<br />{{ crash.device_alias}} </a></b></span>
-    {% endif %}
+    {% set device_ext_url = crash.device_url_template | resolve_device_url(crash.ext_device_id) %}
+    <span class="w-1/6 text-center">device_id<br />
+        {% if crash.alias %}
+        <b><a href="{{ url_for('show_device', device_id=crash.device_id) }}">{{ crash.alias }} ({{ crash.ext_device_id }})</a></b>
+        {% else %}
+        <b><a href="{{ url_for('show_device', device_id=crash.device_id) }}">{{ crash.ext_device_id }}<br />{{ crash.device_alias}} </a></b>
+        {% endif %}
+        {% if device_ext_url %}
+        <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
+            <svg aria-hidden="true" class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+            </svg>
+        </a>
+        {% endif %}
+    </span>
     {% for elf_image in elf_images %}
     <span class="w-1/6 text-center">project_ver<br /><b><a href="{{ url_for('show_build', build_id=elf_image.elf_file_id) }}">{{ crash.project_ver}}<br />{{ elf_image.project_alias }}</a></b></span>
     <span class="w-1/6 text-center">elf_image date<br /><b><a href="{{ url_for('show_build', build_id=elf_image.elf_file_id) }}">{{elf_image.date.strftime('%Y-%m-%d')}}<br />{{elf_image.date.strftime('%H:%M:%S')}}</a></b></span>

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -66,15 +66,21 @@ endblock %}
                         {{ crash.project_ver }}
                     </a>
                 </td>
-                {% if crash.alias %}
+                {% set device_ext_url = crash.device_url_template | resolve_device_url(crash.ext_device_id) %}
                 <td class="px-6 py-4">
+                    {% if crash.alias %}
                     <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, search=crash.ext_device_id) }}">{{ crash.alias }} ({{ crash.ext_device_id }})</a>
-                </td>
-                {% else %}
-                <td class="px-6 py-4">
+                    {% else %}
                     <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, search=crash.ext_device_id) }}">{{ crash.ext_device_id }}</a>
+                    {% endif %}
+                    {% if device_ext_url %}
+                    <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
+                        <svg class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                        </svg>
+                    </a>
+                    {% endif %}
                 </td>
-                {% endif %}
                 <td class="px-6 py-4">
                     {% if crash.module_names %}
                     <div class="flex flex-wrap gap-1">

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -74,7 +74,7 @@ endblock %}
                     <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, search=crash.ext_device_id) }}">{{ crash.ext_device_id }}</a>
                     {% endif %}
                     {% if device_ext_url %}
-                    <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
+                    <a href="{{ device_ext_url }}" target="_blank" rel="noopener noreferrer" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
                         <svg aria-hidden="true" class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                         </svg>

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -74,8 +74,8 @@ endblock %}
                     <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, search=crash.ext_device_id) }}">{{ crash.ext_device_id }}</a>
                     {% endif %}
                     {% if device_ext_url %}
-                    <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
-                        <svg class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <a href="{{ device_ext_url }}" target="_blank" rel="noopener" title="Open external device link" aria-label="Open external device page (opens in new tab)" class="inline-block align-middle ml-1 text-blue-600 hover:text-blue-800">
+                        <svg aria-hidden="true" class="inline w-4 h-4 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                         </svg>
                     </a>

--- a/esp-crash-server/templates/project_settings.html
+++ b/esp-crash-server/templates/project_settings.html
@@ -5,9 +5,12 @@
     <h1 class="text-3xl leading-none text-slate-900">
         Settings for <b>{{ project_name }}</b>
     </h1>
-    <a href="{{ url_for('list_project_crashes', project_name=project_name) }}" class="flex items-center p-2 text-blue-600 hover:underline">
-        <svg class="w-5 h-5 mr-1 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    <a href="{{ url_for('list_project_crashes', project_name=project_name) }}"
+        class="flex items-center p-2 text-blue-600 hover:underline">
+        <svg class="w-5 h-5 mr-1 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
         <span>Back to Project Crashes</span>
     </a>
@@ -30,7 +33,9 @@
                 <td class="px-6 py-4">{{ acl.project_name }}</td>
                 <td class="px-6 py-4">{{ acl.github }}</td>
                 <td class="px-6 py-4">{{ acl.date }}</td>
-                <td class="px-6 py-4"><a href="{{ url_for('delete_acl', project_name=project_name, github=acl.github) }}" class="font-medium text-blue-600 hover:underline">Delete</a></td>
+                <td class="px-6 py-4"><a
+                        href="{{ url_for('delete_acl', project_name=project_name, github=acl.github) }}"
+                        class="font-medium text-blue-600 hover:underline">Delete</a></td>
             </tr>
             {% endfor %}
         </tbody>
@@ -60,7 +65,8 @@
             <tr class="bg-white border-b hover:bg-gray-50">
                 <td class="px-6 py-4">{{ webhook[1] }}</td>
                 <td class="px-6 py-4 text-right">
-                    <form action="{{ url_for('project_webhooks_admin', project_name=project_name) }}" method="post" class="inline">
+                    <form action="{{ url_for('project_webhooks_admin', project_name=project_name) }}" method="post"
+                        class="inline">
                         <input type="hidden" name="action" value="delete">
                         <input type="hidden" name="webhook_id" value="{{ webhook[0] }}">
                         <button type="submit" class="font-medium text-red-600 hover:underline">Delete</button>
@@ -80,10 +86,13 @@
         <input type="hidden" name="action" value="add">
         <div>
             <label for="webhook_url" class="block text-sm font-medium text-gray-700 mb-1">Webhook URL:</label>
-            <input type="url" id="webhook_url" name="webhook_url" required class="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
+            <input type="url" id="webhook_url" name="webhook_url" required
+                class="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
         </div>
         <div>
-            <button type="submit" class="w-full px-4 py-2 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Add Webhook</button>
+            <button type="submit"
+                class="w-full px-4 py-2 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Add
+                Webhook</button>
         </div>
     </form>
 </div>
@@ -112,15 +121,13 @@
                 <td class="px-6 py-4">#{{ integration.slack_channel_name }}</td>
                 <td class="px-6 py-4">{{ integration.created_date|format_datetime }}</td>
                 <td class="px-6 py-4 text-right">
-                    <a href="{{ url_for('verify_slack_integration', project_name=project_name) }}" 
-                       class="font-medium text-purple-600 hover:underline mr-4"
-                       target="_blank">Verify</a>
-                    <a href="{{ url_for('test_slack_integration', project_name=project_name) }}" 
-                       class="font-medium text-green-600 hover:underline mr-4"
-                       target="_blank">Test</a>
-                    <a href="{{ url_for('delete_slack_integration', project_name=project_name, integration_id=integration.slack_integration_id) }}" 
-                       class="font-medium text-red-600 hover:underline"
-                       onclick="return confirm('Are you sure you want to remove this Slack integration?')">Remove</a>
+                    <a href="{{ url_for('verify_slack_integration', project_name=project_name) }}"
+                        class="font-medium text-purple-600 hover:underline mr-4" target="_blank">Verify</a>
+                    <a href="{{ url_for('test_slack_integration', project_name=project_name) }}"
+                        class="font-medium text-green-600 hover:underline mr-4" target="_blank">Test</a>
+                    <a href="{{ url_for('delete_slack_integration', project_name=project_name, integration_id=integration.slack_integration_id) }}"
+                        class="font-medium text-red-600 hover:underline"
+                        onclick="return confirm('Are you sure you want to remove this Slack integration?')">Remove</a>
                 </td>
             </tr>
             {% endfor %}
@@ -137,10 +144,11 @@
         Connect this project to Slack to receive crash notifications directly in your workspace.
     </p>
     <div class="space-y-4">
-        <a href="{{ url_for('slack_auth', project_name=project_name) }}" 
-           class="w-full inline-flex justify-center items-center px-4 py-2 bg-green-600 text-white font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
+        <a href="{{ url_for('slack_auth', project_name=project_name) }}"
+            class="w-full inline-flex justify-center items-center px-4 py-2 bg-green-600 text-white font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
             <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M5.42 9.47c-1.01-.28-2.07.31-2.35 1.32-.28 1.01.31 2.07 1.32 2.35l2.69.74.74-2.69-2.4-.72zm8.1 2.23l1.76-6.39c.28-1.01-.31-2.07-1.32-2.35-1.01-.28-2.07.31-2.35 1.32l-1.76 6.39 2.67.03zm5.13 1.58c1.01.28 2.07-.31 2.35-1.32.28-1.01-.31-2.07-1.32-2.35l-2.69-.74-.74 2.69 2.4.72zm-8.1-2.23l-1.76 6.39c-.28 1.01.31 2.07 1.32 2.35 1.01.28 2.07-.31 2.35-1.32l1.76-6.39-2.67-.03z"/>
+                <path
+                    d="M5.42 9.47c-1.01-.28-2.07.31-2.35 1.32-.28 1.01.31 2.07 1.32 2.35l2.69.74.74-2.69-2.4-.72zm8.1 2.23l1.76-6.39c.28-1.01-.31-2.07-1.32-2.35-1.01-.28-2.07.31-2.35 1.32l-1.76 6.39 2.67.03zm5.13 1.58c1.01.28 2.07-.31 2.35-1.32.28-1.01-.31-2.07-1.32-2.35l-2.69-.74-.74 2.69 2.4.72zm-8.1-2.23l-1.76 6.39c-.28 1.01.31 2.07 1.32 2.35 1.01.28 2.07-.31 2.35-1.32l1.76-6.39-2.67-.03z" />
             </svg>
             Add to Slack
         </a>
@@ -150,30 +158,62 @@
     </div>
 </div>
 
+<div class="w-5/6 mt-12 p-6 bg-white border border-gray-200 rounded-lg shadow mb-4">
+    <h2 class="text-2xl font-semibold mb-4">Device link template</h2>
+    <p class="text-sm text-gray-600 mb-4">
+        Optional. When set, a small "open external link" icon appears next to each
+        device id in the crash list and crash detail views. Use the
+        <code>{{ device_url_placeholder }}</code> token where the device id (the
+        burn-in QR code, or MAC for un-burned units) should go. The id is
+        URL-encoded automatically.<br>
+        Example: <code>https://www.example.com/search/{{ device_url_placeholder }}</code><br>
+        Leave the field empty and save to remove the link.
+    </p>
+    {% if device_url_error %}
+    <p class="text-sm text-red-600 mb-2">
+        Template must start with <code>https://</code> or <code>http://</code> and contain the
+        <code>{{ device_url_placeholder }}</code> token (or be empty to clear it).
+    </p>
+    {% endif %}
+    <form action="{{ url_for('project_device_url_admin', project_name=project_name) }}" method="POST"
+        class="flex items-center">
+        <label for="device_url_template" class="sr-only">Device link template URL</label>
+        <input type="text" id="device_url_template" name="device_url_template" value="{{ device_url_template }}"
+            placeholder="https://www.example.com/search/{{ device_url_placeholder }}"
+            class="p-2 border-2 border-gray-300 rounded-md flex-grow mr-2">
+        <button type="submit" class="p-2 bg-blue-500 text-white rounded-md">Save</button>
+    </form>
+</div>
+
 <div class="w-5/6 mt-12 p-6 bg-white border border-gray-200 rounded-lg shadow">
     <h2 class="text-2xl font-semibold mb-4 border-b pb-2">Integration Information</h2>
-    
+
     <div class="mb-6">
         <h3 class="text-xl font-semibold mb-2">Webhook Integration</h3>
         <p class="text-gray-700 mb-2">
-            Generic webhooks send crash data as JSON to any URL you specify. Perfect for custom integrations or services like Discord, Microsoft Teams, or your own applications.
+            Generic webhooks send crash data as JSON to any URL you specify. Perfect for custom integrations or services
+            like Discord, Microsoft Teams, or your own applications.
         </p>
         <p class="text-sm text-gray-600">
             <strong>Payload includes:</strong> project name, version, crash ID, dump snippet, and details URL
         </p>
     </div>
-    
+
     <div>
         <h3 class="text-xl font-semibold mb-2">Slack Integration</h3>
         <p class="text-gray-700 mb-2">
-            Native Slack integration provides rich formatting with crash details displayed as interactive blocks, including action buttons to view crash details directly.
+            Native Slack integration provides rich formatting with crash details displayed as interactive blocks,
+            including action buttons to view crash details directly.
         </p>
         <p class="text-sm text-gray-600 mb-2">
-            <strong>Features:</strong> Rich message formatting, action buttons, automatic channel detection, team-specific tokens
+            <strong>Features:</strong> Rich message formatting, action buttons, automatic channel detection,
+            team-specific tokens
         </p>
         <div class="bg-yellow-50 border border-yellow-200 rounded-md p-3 mt-3">
             <p class="text-yellow-800 text-sm">
-                <strong>💡 Important:</strong> To see test messages and crash notifications, make sure you're a member of the Slack workspace and have access to the configured channel. If you don't see messages after a successful test, check that you're logged into the correct Slack workspace.
+                <strong>💡 Important:</strong> To see test messages and crash notifications, make sure you're a member
+                of the Slack workspace and have access to the configured channel. If you don't see messages after a
+                successful test, check that you're logged into the correct Slack workspace.
             </p>
         </div>
     </div>

--- a/esp-crash-server/test_device_url.py
+++ b/esp-crash-server/test_device_url.py
@@ -41,3 +41,30 @@ def test_validation_blank_is_valid():
 def test_validation_requires_placeholder_when_non_blank():
     assert device_url_template_is_valid("https://x.test/s/{device_id}") is True
     assert device_url_template_is_valid("https://x.test/no-token") is False
+
+
+# --- scheme-safety tests (Change 2) ---
+
+
+def test_validation_rejects_javascript_scheme():
+    assert device_url_template_is_valid("javascript:alert(1)/{device_id}") is False
+
+
+def test_validation_rejects_ftp_scheme():
+    assert device_url_template_is_valid("ftp://x.test/{device_id}") is False
+
+
+def test_validation_accepts_http_scheme():
+    assert device_url_template_is_valid("http://x.test/{device_id}") is True
+
+
+def test_validation_accepts_https_scheme_case_insensitive():
+    assert device_url_template_is_valid("HTTPS://X.TEST/{device_id}") is True
+
+
+def test_resolve_returns_none_for_javascript_scheme():
+    assert resolve_device_url("javascript:alert(1)/{device_id}", "ABC") is None
+
+
+def test_resolve_returns_none_for_ftp_scheme():
+    assert resolve_device_url("ftp://x.test/{device_id}", "ABC") is None

--- a/esp-crash-server/test_device_url.py
+++ b/esp-crash-server/test_device_url.py
@@ -1,0 +1,43 @@
+from device_url import (
+    DEVICE_ID_PLACEHOLDER,
+    device_url_template_is_valid,
+    resolve_device_url,
+)
+
+
+def test_placeholder_token_is_device_id():
+    assert DEVICE_ID_PLACEHOLDER == "{device_id}"
+
+
+def test_resolve_substitutes_device_id():
+    url = resolve_device_url("https://www.example.com/search/{device_id}", "ABC123")
+    assert url == "https://www.example.com/search/ABC123"
+
+
+def test_resolve_url_encodes_device_id():
+    url = resolve_device_url("https://x.test/s/{device_id}", "a b/c?d")
+    assert url == "https://x.test/s/a%20b%2Fc%3Fd"
+
+
+def test_resolve_returns_none_for_blank_template():
+    assert resolve_device_url("", "ABC123") is None
+    assert resolve_device_url(None, "ABC123") is None
+
+
+def test_resolve_returns_none_when_placeholder_missing():
+    assert resolve_device_url("https://x.test/no-token", "ABC123") is None
+
+
+def test_resolve_handles_missing_device_id():
+    assert resolve_device_url("https://x.test/s/{device_id}", None) == "https://x.test/s/"
+
+
+def test_validation_blank_is_valid():
+    assert device_url_template_is_valid("") is True
+    assert device_url_template_is_valid("   ") is True
+    assert device_url_template_is_valid(None) is True
+
+
+def test_validation_requires_placeholder_when_non_blank():
+    assert device_url_template_is_valid("https://x.test/s/{device_id}") is True
+    assert device_url_template_is_valid("https://x.test/no-token") is False


### PR DESCRIPTION
- add project_settings table with migration script
- add endpoint to set a project setting to set an external device url based on a template
- add an external link on the project coredump list page, when the external url project setting is set

⚠️  The migration needs to be run for the existing projects to support this feature (use esp-crash-server/project_settings_migration.sql)

