### PR TITLE
update module coredump decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ as raw addresses.
 
 The device records a small **module registry** in a `COREDUMP_DRAM_ATTR`
 variable, so it is captured inside every coredump. Each record holds the
-module's name, the SHA1 of the over-the-wire `.app` bytes, and its section
-runtime addresses. There are two ways to use it:
+module's name, its version string, the SHA1 of the over-the-wire `.app` bytes,
+and its section runtime addresses. There are two ways to use it:
 
 - **Server-side (automatic):** pre-upload each module's debug ELF, keyed by the
   SHA1 of its `.app` bytes. When a dump arrives, the backend reads the registry,
@@ -233,7 +233,7 @@ Each record must contain these fields (names matter — the gdb scripts referenc
 them by name):
 
 ```
-record  { char name[]; uint8_t sha1[20];
+record  { char name[]; char version[]; uint8_t sha1[20];
           section text; section data; section bss; section rodata; }
 section { uint32_t addr; uint32_t v_addr; uint32_t size; }
 ```
@@ -258,7 +258,8 @@ typedef struct {
 } mod_map_section_t;
 
 typedef struct {
-    char    name[64];
+    char    name[32];     // NUL-terminated module name
+    char    version[24];  // NUL-terminated version string (informational)
     uint8_t sha1[20];
     mod_map_section_t text, data, bss, rodata;
 } mod_record_t;
@@ -272,6 +273,13 @@ The `sha1` field is the SHA1 of the over-the-wire `.app` bytes and is the join k
 for **server-side** symbolication: the backend matches it against the `app_sha1`
 used when uploading the module ELF. The **local** CLI matches by name instead
 (it has the debug `.elf`, not the wire `.app`), so there `sha1` is informational.
+
+The `version` field is a free-form module version string (e.g.
+`"1560-a6f50c32-dirty"`). It is informational — not used for matching — and is
+surfaced on the crash page's module card alongside the name and SHA1. Field
+sizes are up to your firmware; the decoder reads each field symbolically by name
+from DWARF, so only the field **names** (`name`, `version`, `sha1`, the section
+members) must match.
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ runtime addresses. There are two ways to use it:
   SHA1 of its `.app` bytes. When a dump arrives, the backend reads the registry,
   matches each module by SHA1, and symbolicates automatically.
 - **Local:** run `esp-crash-server/decode_module_coredump.py` against a dump you
-  downloaded, supplying each module ELF by name. The script reads the registry,
-  generates a GDB `add-symbol-file` line per module (placing each section at its
-  on-device runtime address), and hands it to `esp-coredump`.
+  downloaded, supplying each module ELF by name. The script runs `esp-coredump`
+  with a checked-in gdb macro that reads the registry symbolically (by the
+  `s_mod_map` symbol) and issues an `add-symbol-file` per module, each section
+  placed at its on-device runtime address as evaluated by gdb against the dump.
 
 ### Uploading module ELFs
 
@@ -216,114 +217,61 @@ python esp-crash-server/decode_module_coredump.py info \
 - Module names found in the dump with no matching `--module-elf` are skipped
   with a warning; the rest of the dump still decodes.
 
-### On-device registry format
+### On-device registry contract
 
-For the script to find your modules, the firmware must expose a registry in this
-exact binary layout (little-endian, 4-byte aligned). It is a magic-tagged header
-followed by a fixed-capacity array of module records; the script scans `PT_LOAD`
-segments of the coredump for the `MODM` magic.
+The decoder reads the module registry **symbolically** — it never scans the dump
+for a magic tag. Your firmware must expose a symbol named `s_mod_map` that is:
+
+- an **array of module records** (`mod_record_t s_mod_map[N]`), where `N` is your
+  concurrent-module cap;
+- placed in `COREDUMP_DRAM_ATTR` storage so it lands in every coredump;
+- present in the **program ELF with DWARF type info** (an unstripped, `-g` build —
+  the default). gdb reads the slot count from the array type and each field from
+  the dump, so there is no host-side knowledge of the byte layout.
+
+Each record must contain these fields (names matter — the gdb scripts reference
+them by name):
 
 ```
-registry { u32 magic = 0x4D4F444D ('MODM'); u8 capacity; u8 pad[3];
-           record  modules[capacity]; }
-record   { char name[64]; u8 sha1[20];
-           section text; section data; section bss; section rodata; }
-section  { u32 addr; u32 v_addr; u32 size; }
+record  { char name[]; uint8_t sha1[20];
+          section text; section data; section bss; section rodata; }
+section { uint32_t addr; uint32_t v_addr; uint32_t size; }
 ```
 
-`addr` is the **runtime** address of the section (what GDB needs), `v_addr` is
-the ELF link-time virtual address, `size` is the section size. A slot is
-considered occupied only when `name[0] != 0` **and** `text.addr != 0`; zeroed
-slots (free) and slots with a name but `text.addr == 0` (mid-load) are skipped.
+`addr` is the **runtime** address of the section (what gdb's `add-symbol-file`
+needs), `v_addr` is the ELF link-time virtual address, `size` is the section size.
+A slot is occupied iff `name[0] != 0` **and** `text.addr != 0`; zeroed slots (free)
+and slots with a name but `text.addr == 0` (mid-load) are skipped.
 
 ### C example
-
-Declare the registry once, in `COREDUMP_DRAM_ATTR` storage so it lands in the
-dump, and populate a slot when you load a module:
 
 ```c
 #include "esp_attr.h"   // COREDUMP_DRAM_ATTR
 #include <stdint.h>
-#include <string.h>
 
-#define MOD_MAP_MAGIC        0x4D4F444DU  // 'MODM'
-#define MOD_MAP_MAX_MODULES  4            // your concurrent-module cap
-#define MOD_MAP_NAME_LEN     64
-#define MOD_MAP_SHA1_LEN     20
+#define MOD_MAP_MAX_MODULES  4   // your concurrent-module cap
 
 typedef struct {
-    uint32_t addr;    // runtime address (passed to GDB add-symbol-file)
+    uint32_t addr;    // runtime address (passed to add-symbol-file via gdb)
     uint32_t v_addr;  // ELF link-time virtual address
     uint32_t size;
 } mod_map_section_t;
 
 typedef struct {
-    char    name[MOD_MAP_NAME_LEN];
-    uint8_t sha1[MOD_MAP_SHA1_LEN];
-    mod_map_section_t text;
-    mod_map_section_t data;
-    mod_map_section_t bss;
-    mod_map_section_t rodata;
+    char    name[64];
+    uint8_t sha1[20];
+    mod_map_section_t text, data, bss, rodata;
 } mod_record_t;
 
-// Layout is parsed byte-for-byte by decode_module_coredump.py — keep it pinned.
-_Static_assert(sizeof(mod_record_t) == 132, "mod_record layout drifted");
-
-typedef struct {
-    uint32_t magic;
-    uint8_t  capacity;
-    uint8_t  _pad[3];
-    mod_record_t modules[MOD_MAP_MAX_MODULES];
-} mod_map_registry_t;
-
-_Static_assert(offsetof(mod_map_registry_t, modules) == 8, "header drifted");
-
-// COREDUMP_DRAM_ATTR forces this into the .dram2.coredump region captured in
-// every coredump.
-COREDUMP_DRAM_ATTR static mod_map_registry_t s_mod_map = {
-    .magic    = MOD_MAP_MAGIC,
-    .capacity = MOD_MAP_MAX_MODULES,
-};
-
-// Call after a module's ELF is loaded. `sec_*` come from your ELF loader.
-void module_registry_record(const char *name, const uint8_t sha1[20],
-                            const mod_map_section_t *text,
-                            const mod_map_section_t *data,
-                            const mod_map_section_t *bss,
-                            const mod_map_section_t *rodata)
-{
-    for (uint8_t i = 0; i < MOD_MAP_MAX_MODULES; ++i) {
-        mod_record_t *r = &s_mod_map.modules[i];
-        if (r->name[0] != '\0') {
-            continue; // slot taken
-        }
-        memset(r, 0, sizeof(*r));
-        strlcpy(r->name, name, sizeof(r->name));
-        memcpy(r->sha1, sha1, MOD_MAP_SHA1_LEN);
-        r->text = *text; r->data = *data; r->bss = *bss; r->rodata = *rodata;
-        return;
-    }
-    // registry full — module won't be symbolicated, but the dump is still valid
-}
-
-// On unload, zero the slot so it reads as free.
-void module_registry_clear(const char *name)
-{
-    for (uint8_t i = 0; i < MOD_MAP_MAX_MODULES; ++i) {
-        if (strcmp(s_mod_map.modules[i].name, name) == 0) {
-            memset(&s_mod_map.modules[i], 0, sizeof(s_mod_map.modules[i]));
-            return;
-        }
-    }
-}
+// No magic, no capacity header: the decoder locates this by the `s_mod_map`
+// symbol and reads N from the DWARF array type.
+COREDUMP_DRAM_ATTR static mod_record_t s_mod_map[MOD_MAP_MAX_MODULES];
 ```
 
-The `sha1` field is the SHA1 of the over-the-wire `.app` bytes and is the join
-key for **server-side** symbolication: the backend matches it against the
-`app_sha1` you used when uploading the module ELF. The **local** script matches
-modules by name instead, so there `sha1` is only reported for confirmation. If
-you never use server-side symbolication you may leave it zeroed, but populating
-it is what makes the automatic path work.
+The `sha1` field is the SHA1 of the over-the-wire `.app` bytes and is the join key
+for **server-side** symbolication: the backend matches it against the `app_sha1`
+used when uploading the module ELF. The **local** CLI matches by name instead
+(it has the debug `.elf`, not the wire `.app`), so there `sha1` is informational.
 
 ## Example Output
 

--- a/esp-crash-server/db_schema.sql
+++ b/esp-crash-server/db_schema.sql
@@ -4,6 +4,10 @@ CREATE TABLE IF NOT EXISTS crash (crash_id SERIAL PRIMARY KEY, "date" TIMESTAMP,
 -- cron processing time so the crash list can render "Modules" tags without
 -- parsing every coredump per page load.
 ALTER TABLE crash ADD COLUMN IF NOT EXISTS module_names TEXT[];
+-- Per-module identity (name + wire-.app sha1) read from the coredump at cron
+-- time, so the crash detail page can render module tags + availability without
+-- re-running gdb on each page load. Availability is computed live from module_elf.
+ALTER TABLE crash ADD COLUMN IF NOT EXISTS module_map JSONB;
 CREATE TABLE IF NOT EXISTS elf_file (elf_file_id SERIAL PRIMARY KEY, "date" TIMESTAMP, project_name TEXT, project_ver TEXT, elf_file BYTEA, file_size INTEGER, project_alias TEXT);
 CREATE TABLE IF NOT EXISTS project_auth (project_auth_id SERIAL PRIMARY KEY, "date" TIMESTAMP, project_name TEXT, github TEXT);
 CREATE INDEX IF NOT EXISTS textsearch_idx ON crash USING GIN (textsearch);

--- a/esp-crash-server/decode_module_coredump.py
+++ b/esp-crash-server/decode_module_coredump.py
@@ -2,191 +2,47 @@
 """
 Decode ESP32 core dumps with dynamically loaded ELF module symbols.
 
-The on-device module map embedded in .dram2.coredump is read straight from
-the dump. Just supply each loaded module's ELF, mapped by name.
+The on-device module registry is read from the coredump by resolving the
+`s_mod_map` symbol via gdb and printing its fields with plain gdb `printf`
+commands (no gdb-Python: the Espressif toolchain gdb is built without Python
+scripting). Module frames are then symbolicated by handing gdb literal
+`add-symbol-file <elf> <text> -s .data <data> ...` commands whose addresses are
+the runtime section bases read straight out of the registry.
+
+Flow (host-driven, gdb invoked directly on a saved core ELF):
+
+  1. esp-coredump converts the raw dump partition image into a core ELF
+     (`--save-core`) and gives us the base panic/backtrace text.
+  2. plain gdb reads `s_mod_map` from the core ELF -> [{name, sha1, sections}].
+  3. each module's debug ELF is resolved (server: by sha1; local CLI: by name).
+  4. plain gdb re-runs with literal `add-symbol-file` per module and prints a
+     module-symbolicated backtrace.
+
+Local usage (modules matched by name):
 
   python decode_module_coredump.py dbg \
       --core crash.dmp \
       --prog build/pulse-ir-hub-esp32.elf \
       --module-elf ems-goodwe=ems-goodwe/build_bridge/ems-goodwe.app.elf
-
-On-device map format (little-endian, 4-byte aligned):
-  registry { u32 magic=0x4D4F444D ('MODM'); u8 capacity; pad[3];
-             entry modules[capacity]; }   # capacity = CONFIG_MOD_LOADER_MAX_MODULES
-  entry    { char name[64]; u8 sha1[20]; section text; section data;
-             section bss; section rodata; }
-  section  { u32 addr; u32 v_addr; u32 size; }
-
-The array is sparse: a slot is occupied iff name[0] != 0 and its .text addr is
-non-zero. Released slots are zeroed; mid-load slots have a name but a zero .text.
 """
 
 import argparse
-import io
+import glob
 import os
-import struct
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
-from elftools.elf.elffile import ELFFile
+# Section names whose runtime base addresses the registry records and gdb's
+# add-symbol-file needs. `text` is the positional base; the rest are `-s`.
+SECTION_FIELDS = ("text", "data", "bss", "rodata")
 
-MOD_MAP_MAGIC = 0x4D4F444D  # 'MODM' as LE u32
-MOD_MAP_NAME_LEN = 64
-MOD_MAP_SHA1_LEN = 20
-SECTION_SIZE = 12
-ENTRY_SIZE = MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN + 4 * SECTION_SIZE  # 64 + 20 + 48 = 132
-REGISTRY_HEADER_SIZE = 8  # u32 magic + u8 capacity + 3 pad bytes
-
-# The on-device array size is a build-time Kconfig (CONFIG_MOD_LOADER_MAX_MODULES,
-# range 1..32). The registry header records the actual capacity so we never need
-# to guess; this is only the upper bound we trust for a candidate header.
-MOD_MAP_CAPACITY_LIMIT = 32
-
-# Mirror of the C-side _Static_assert in mod_loader_registry.c — keep these in sync.
-assert ENTRY_SIZE == 132, "ENTRY_SIZE drifted from mod_record (must be 132)"
-ELF_MAGIC = b"\x7fELF"
-
-
-def _is_plausible_addr(addr: int) -> bool:
-    """
-    Coarse sanity filter for ESP32 runtime addresses. Module sections live in
-    the IRAM/IROM bus window (.text/.rodata via flash mmap) or in DRAM
-    (.data/.bss on heap). Anything outside these ranges means we hit a stray
-    'MODM' byte sequence somewhere else in the dump.
-    """
-    if addr == 0:
-        return True  # unused slots are zero
-    return 0x3F000000 <= addr < 0x60000000
-
-
-def _decode_entry(blob: bytes, offset: int) -> dict | None:
-    raw_name = blob[offset : offset + MOD_MAP_NAME_LEN]
-    name = raw_name.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
-    if not name or any(ord(c) < 0x20 or ord(c) > 0x7E for c in name):
-        return None
-
-    sha1_bytes = blob[
-        offset + MOD_MAP_NAME_LEN : offset + MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN
-    ]
-    sha1_hex = sha1_bytes.hex()
-
-    sec_base = offset + MOD_MAP_NAME_LEN + MOD_MAP_SHA1_LEN
-    out = {"name": name, "sha1": sha1_hex}
-    for i, sec_name in enumerate(("text", "data", "bss", "rodata")):
-        addr, v_addr, size = struct.unpack_from(
-            "<III", blob, sec_base + i * SECTION_SIZE
-        )
-        # A committed module's .text always maps into the IRAM/IROM window and
-        # is never 0; .text == 0 means the slot was acquired but not yet
-        # committed (mid-load) or was released, so skip it.
-        if sec_name == "text" and addr == 0:
-            return None
-        if not _is_plausible_addr(addr):
-            return None
-        out[f"{sec_name}_addr"] = f"0x{addr:08x}"
-        out[f"{sec_name}_vaddr"] = f"0x{v_addr:08x}"
-        out[f"{sec_name}_size"] = size
-    return out
-
-
-def _decode_registry(blob: bytes, offset: int) -> list[dict] | None:
-    """
-    Try to decode a registry header at `offset`. Returns the list of decoded
-    occupied entries (possibly empty), or None if the candidate fails
-    validation. The header self-describes its slot capacity; the array is
-    sparse, so empty/uncommitted/corrupt slots are skipped individually rather
-    than failing the whole registry.
-    """
-    if offset + REGISTRY_HEADER_SIZE > len(blob):
-        return None
-    capacity = blob[offset + 4]
-    if capacity < 1 or capacity > MOD_MAP_CAPACITY_LIMIT:
-        return None
-    if offset + REGISTRY_HEADER_SIZE + capacity * ENTRY_SIZE > len(blob):
-        return None
-    entries: list[dict] = []
-    for i in range(capacity):
-        entry_offset = offset + REGISTRY_HEADER_SIZE + i * ENTRY_SIZE
-        decoded = _decode_entry(blob, entry_offset)
-        if decoded is not None:
-            entries.append(decoded)
-    return entries
-
-
-def parse_module_map_from_coredump(core_path: str, verbose: bool = False) -> list[dict]:
-    """
-    Read the on-device module map out of an ELF-format core dump.
-
-    The coredump is always an ELF (CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y is
-    the default). The .dram2.coredump section is captured as part of a
-    PT_LOAD program header; we search the MODM magic only inside those
-    segments to avoid false positives in ELF metadata or other regions.
-
-    When the file was read raw from flash, a small chip-side header may
-    precede the ELF; we skip past it by locating the first ELF magic.
-    """
-    raw = Path(core_path).read_bytes()
-    elf_offset = raw.find(ELF_MAGIC)
-    if elf_offset < 0:
-        raise ValueError(
-            f"{core_path}: no ELF header found (is this an ESP-IDF coredump?)"
-        )
-
-    if verbose:
-        print(
-            f"DEBUG: coredump bytes={len(raw)} elf_offset=0x{elf_offset:x}",
-            file=sys.stderr,
-        )
-
-    elf_bytes = raw[elf_offset:]
-    needle = struct.pack("<I", MOD_MAP_MAGIC)
-    modules: list[dict] = []
-    seen_segments = 0
-    load_segments = 0
-    candidate_hits = 0
-    decoded_entries = 0
-
-    with ELFFile(io.BytesIO(elf_bytes)) as elf:
-        for segment in elf.iter_segments():
-            if segment.header.p_type != "PT_LOAD":
-                continue
-            load_segments += 1
-            data = segment.data()
-            pos = 0
-            while True:
-                pos = data.find(needle, pos)
-                if pos < 0:
-                    break
-                candidate_hits += 1
-                entries = _decode_registry(data, pos)
-                if entries is None:
-                    pos += 1
-                    continue
-                modules.extend(entries)
-                decoded_entries += len(entries)
-                seen_segments += 1
-                capacity = data[pos + 4]
-                pos += REGISTRY_HEADER_SIZE + capacity * ENTRY_SIZE
-
-    if verbose:
-        print(
-            "DEBUG: "
-            f"pt_load_segments={load_segments} "
-            f"modm_hits={candidate_hits} "
-            f"valid_registries={seen_segments} "
-            f"decoded_entries={decoded_entries}",
-            file=sys.stderr,
-        )
-
-    if seen_segments > 1:
-        print(
-            f"NOTE: found {seen_segments} module-map candidates in coredump; "
-            "merged all entries.",
-            file=sys.stderr,
-        )
-    return modules
+# Delimited line emitted by the gdb registry-read script, one per slot:
+#   MODSLOT|<i>|<name>|<sha1-hex>|<text>|<data>|<bss>|<rodata>
+MODSLOT_PREFIX = "MODSLOT|"
+NSLOTS_PREFIX = "NSLOTS="
 
 
 def parse_elf_map_arg(spec: str) -> tuple[str, str]:
@@ -197,73 +53,173 @@ def parse_elf_map_arg(spec: str) -> tuple[str, str]:
     return name, path
 
 
-def generate_gdbinit(modules: list[dict], output_path: str):
-    """Generate a GDB init file with add-symbol-file commands."""
-    with open(output_path, "w") as f:
-        f.write("# Auto-generated by decode_module_coredump.py\n")
-        f.write("# Module symbol loading commands\n\n")
-        for mod in modules:
-            elf = mod["elf"]
-            # Path written into the add-symbol-file line. Defaults to the path
-            # we read below; callers (e.g. the download packager) can set
-            # 'elf_display' to a relative path that is valid where gdb runs.
-            elf_display = mod.get("elf_display", elf)
-            # Parse addresses (may be int or hex string)
-            text_runtime = int(mod["text_addr"], 16) if isinstance(mod["text_addr"], str) and mod["text_addr"].startswith("0x") else int(mod["text_addr"])
-            data = int(mod["data_addr"], 16) if isinstance(mod["data_addr"], str) and mod["data_addr"].startswith("0x") else int(mod["data_addr"])
-            bss = int(mod["bss_addr"], 16) if isinstance(mod["bss_addr"], str) and mod["bss_addr"].startswith("0x") else int(mod["bss_addr"])
-            rodata = int(mod["rodata_addr"], 16) if isinstance(mod["rodata_addr"], str) and mod["rodata_addr"].startswith("0x") else int(mod["rodata_addr"])
-
-            # `add-symbol-file FILE <addr>` expects <addr> to be the *runtime*
-            # address of the .text section; GDB computes the per-section slide
-            # itself as (addr - the ELF's .text sh_addr). text_runtime already IS
-            # that runtime address, so pass it as-is. Do NOT pre-subtract the
-            # ELF's .text vaddr: when sh_addr != 0 (ESP ELF modules link .text at
-            # a small non-zero vaddr) that double-counts the vaddr and shifts
-            # every symbol, mislabeling frames to the next function up.
-            f.write(f"echo \\n=== Loading module '{mod['name']}' symbols ===\\n\n")
-            f.write(
-                f"add-symbol-file {elf_display} {hex(text_runtime)} "
-                f"-s .data {hex(data)} "
-                f"-s .bss {hex(bss)} "
-                f"-s .rodata {hex(rodata)}\n"
-            )
-        f.write("\necho \\n=== Module symbols loaded. Use 'bt' or 'info threads' ===\\n\n")
+def find_gdb(explicit: str | None = None) -> str:
+    """Locate an xtensa gdb. Any build works (we issue only plain commands, no
+    Python). Order: explicit arg, $MODULE_GDB, PATH, common IDF tool dirs."""
+    if explicit:
+        return explicit
+    env = os.environ.get("MODULE_GDB")
+    if env:
+        return env
+    for name in ("xtensa-esp32-elf-gdb", "xtensa-esp-elf-gdb"):
+        found = shutil.which(name)
+        if found:
+            return found
+    roots = ("/opt/esp/tools", os.path.expanduser("~/.espressif/tools"))
+    for root in roots:
+        hits = glob.glob(os.path.join(root, "**", "xtensa-esp32-elf-gdb"), recursive=True)
+        if hits:
+            return sorted(hits)[-1]
+    return "xtensa-esp32-elf-gdb"  # last resort; will fail loudly if absent
 
 
-def run_espcoredump(args, modules: list[dict], operation: str):
-    """Symbolicate a coredump, loading any module symbols via gdbinit.
-
-    The whole job is: generate a gdbinit with add-symbol-file lines for the
-    modules, then hand it to the esp-coredump console script through its native
-    --extra-gdbinit-file (honored by esp_coredump's CLI; see coredump.py). The
-    stored coredump is a raw partition image, so -t raw parses it directly — no
-    normalization needed.
-    """
-    gdbinit_path = None
+def save_core(
+    dmp: str, prog: str, *, core_format: str = "raw", gdb: str | None = None
+) -> tuple[str, str]:
+    """Convert the raw dump into a core ELF via esp-coredump and capture the
+    base (module-unaware) panic/backtrace text. Returns (core_elf_path, text).
+    The caller owns the returned core ELF file and must unlink it."""
+    fd, core_elf = tempfile.mkstemp(suffix=".elf", prefix="core_")
+    os.close(fd)
+    cmd = ["esp-coredump", "info_corefile", "-t", core_format, "-c", dmp,
+           "--save-core", core_elf, "--gdb", find_gdb(gdb)]
+    cmd.append(prog)
     try:
-        cmd = ["esp-coredump", operation, "-t", args.core_format, "-c", args.core]
-        if modules:
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".gdbinit", delete=False, prefix="mod_"
-            ) as f:
-                gdbinit_path = f.name
-            generate_gdbinit(modules, gdbinit_path)
-            cmd += ["--extra-gdbinit-file", gdbinit_path]
-            print(f"Generated GDB init: {gdbinit_path}", file=sys.stderr)
-        if args.gdb:
-            cmd += ["--gdb", args.gdb]
-        cmd.append(args.prog)
-        print(f"Running: {' '.join(cmd)}", file=sys.stderr)
-        subprocess.run(cmd)
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as e:
+        # esp-coredump not found / not executable: degrade to an empty core
+        # (the caller still owns and cleans the temp file).
+        return core_elf, f"# esp-coredump unavailable: {e}\n"
+    return core_elf, (proc.stdout + proc.stderr).decode("utf-8", "replace")
+
+
+def _gdb_batch(gdb: str, prog: str, core_elf: str, commands: list[str]) -> str:
+    """Run gdb in batch on (prog, core_elf), executing `commands` in order after
+    the core is loaded, and return combined stdout+stderr. Never raises."""
+    args = [gdb, "-batch", "-nx", prog, "-ex", f"core-file {core_elf}"]
+    for c in commands:
+        args += ["-ex", c]
+    try:
+        proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError:
+        return ""  # gdb not found / not executable: best-effort, no symbols
+    return (proc.stdout + proc.stderr).decode("utf-8", "replace")
+
+
+def _slot_printf(i: int) -> str:
+    """gdb `printf` command that emits one delimited MODSLOT line for slot i,
+    including the 20-byte sha1 as hex and the four section base addresses."""
+    sha = "".join("%02x" for _ in range(20))
+    sha_args = ", ".join(f"s_mod_map[{i}].sha1[{b}]" for b in range(20))
+    addr_args = ", ".join(f"s_mod_map[{i}].{s}.addr" for s in SECTION_FIELDS)
+    fmt = f"{MODSLOT_PREFIX}{i}|%s|{sha}|%u|%u|%u|%u\\n"
+    return f'printf "{fmt}", s_mod_map[{i}].name, {sha_args}, {addr_args}'
+
+
+def parse_registry_output(text: str) -> list[dict]:
+    """Parse MODSLOT lines into occupied-slot records. Best-effort: a slot is
+    occupied iff name is non-empty and text.addr != 0. Returns
+    [{name, sha1, text, data, bss, rodata}] with addresses as ints."""
+    mods = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith(MODSLOT_PREFIX):
+            continue
+        parts = line.split("|")
+        # MODSLOT | idx | name | sha1 | text | data | bss | rodata
+        if len(parts) != 8:
+            continue
+        _, _idx, name, sha1, t, d, b, r = parts
+        try:
+            text_addr, data_addr, bss_addr, rodata_addr = (
+                int(t) & 0xffffffff, int(d) & 0xffffffff,
+                int(b) & 0xffffffff, int(r) & 0xffffffff,
+            )
+        except ValueError:
+            continue
+        if not name or text_addr == 0:
+            continue  # free or mid-load slot
+        mods.append({
+            "name": name, "sha1": sha1,
+            "text": text_addr, "data": data_addr,
+            "bss": bss_addr, "rodata": rodata_addr,
+        })
+    return mods
+
+
+def read_registry(core_elf: str, prog: str, *, gdb: str | None = None) -> list[dict]:
+    """Read `s_mod_map` from the core ELF using plain gdb commands. Returns
+    occupied-slot records (possibly empty). Never raises on a missing symbol."""
+    gdb = find_gdb(gdb)
+    # Pass A: how many slots? (sizeof from DWARF; works without the core loaded
+    # but we load it anyway for a single, simple invocation path.)
+    out = _gdb_batch(gdb, prog, core_elf,
+                     [f'printf "{NSLOTS_PREFIX}%d\\n", '
+                      f'(int)(sizeof(s_mod_map)/sizeof(s_mod_map[0]))'])
+    n = 0
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith(NSLOTS_PREFIX):
+            try:
+                n = int(line[len(NSLOTS_PREFIX):])
+            except ValueError:
+                n = 0
+            break
+    if n <= 0:
+        return []  # no s_mod_map symbol, or unreadable
+    # Pass B: dump each slot.
+    out = _gdb_batch(gdb, prog, core_elf, [_slot_printf(i) for i in range(n)])
+    return parse_registry_output(out)
+
+
+def addsym_commands(loaded: list[dict]) -> list[str]:
+    """Build literal `add-symbol-file` gdb commands for resolved modules.
+    `loaded` items are registry records (text/data/bss/rodata ints) plus an
+    'elf' path. Addresses are emitted as hex so any gdb can place the sections
+    without evaluating the registry."""
+    cmds = []
+    for m in loaded:
+        cmds.append(
+            "add-symbol-file {elf} {text:#x} "
+            "-s .data {data:#x} -s .bss {bss:#x} -s .rodata {rodata:#x}".format(**m)
+        )
+    return cmds
+
+
+def write_addsym_gdbinit(loaded: list[dict]) -> str:
+    """Write literal add-symbol-file commands for `loaded` to a temp gdbinit and
+    return its path. esp-coredump sources it via --extra-gdbinit-file so its own
+    panic report resolves module frames inline. The caller must delete the file."""
+    fd, path = tempfile.mkstemp(suffix=".gdbinit", prefix="modsym_")
+    with os.fdopen(fd, "w") as f:
+        cmds = addsym_commands(loaded)
+        f.write("\n".join(cmds))
+        if cmds:
+            f.write("\n")
+    return path
+
+
+def symbolicated_report(
+    dmp: str, prog: str, loaded: list[dict], *,
+    core_format: str = "raw", gdb: str | None = None,
+) -> str:
+    """Re-run esp-coredump with a literal add-symbol-file gdbinit so its full
+    panic report (registers, every thread's stack, task table) has the module
+    frames resolved inline. Returns the report text. Best-effort."""
+    gi = write_addsym_gdbinit(loaded)
+    try:
+        cmd = ["esp-coredump", "info_corefile", "-t", core_format, "-c", dmp,
+               "--gdb", find_gdb(gdb), "--extra-gdbinit-file", gi, prog]
+        try:
+            proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError as e:
+            return f"# esp-coredump unavailable: {e}\n"
+        return (proc.stdout + proc.stderr).decode("utf-8", "replace")
     finally:
-        # Keep the gdbinit for interactive sessions so the user can re-source it;
-        # otherwise clean it up.
-        if gdbinit_path:
-            if operation == "dbg_corefile":
-                print(f"\nGDB init file preserved at: {gdbinit_path}", file=sys.stderr)
-            else:
-                os.unlink(gdbinit_path)
+        try:
+            os.remove(gi)
+        except OSError:
+            pass
 
 
 def main():
@@ -272,80 +228,66 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
-
-    parser.add_argument(
-        "operation",
-        choices=["dbg", "info"],
-        help="'dbg' for interactive GDB, 'info' for backtrace summary",
-    )
-    parser.add_argument(
-        "--core", "-c", required=True, help="Path to core dump file (raw binary)"
-    )
-    parser.add_argument(
-        "--core-format",
-        "-t",
-        choices=["auto", "b64", "elf", "raw"],
-        default="raw",
-        dest="core_format",
-        help="Core dump format passed to esp-coredump (default: raw)",
-    )
-    parser.add_argument(
-        "--prog", "-p", required=True, help="Path to host application ELF"
-    )
-    parser.add_argument(
-        "--module-elf",
-        action="append",
-        default=[],
-        help=(
-            "Module ELF mapping 'name=path' (repeatable). Used to resolve "
-            "names found in the on-device module map embedded in the coredump."
-        ),
-    )
-    parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Print extraction diagnostics (ELF offset, PT_LOAD scans, MODM hits).",
-    )
-    parser.add_argument(
-        "--gdb",
-        help="Path to GDB executable passed to espcoredump.py (for example /opt/homebrew/bin/gdb).",
-    )
-
+    parser.add_argument("operation", choices=["dbg", "info"],
+                        help="'dbg' for interactive GDB, 'info' for a backtrace summary")
+    parser.add_argument("--core", "-c", required=True, help="Path to core dump file")
+    parser.add_argument("--core-format", "-t", choices=["auto", "b64", "elf", "raw"],
+                        default="raw", dest="core_format",
+                        help="Core dump format passed to esp-coredump (default: raw)")
+    parser.add_argument("--prog", "-p", required=True, help="Path to host application ELF")
+    parser.add_argument("--module-elf", action="append", default=[],
+                        help="Module ELF mapping 'name=path' (repeatable). Matched by "
+                             "module name against the on-device registry.")
+    parser.add_argument("--gdb", help="Path to the xtensa GDB executable.")
     args = parser.parse_args()
 
-    elf_map: dict[str, str] = {}
+    by_name: dict[str, str] = {}
     for spec in args.module_elf:
         name, path = parse_elf_map_arg(spec)
-        elf_map[name] = path
+        by_name[name] = path
 
-    modules: list[dict] = []
-    for m in parse_module_map_from_coredump(args.core, args.verbose):
-        elf = elf_map.get(m["name"])
-        if not elf:
-            print(
-                f"WARNING: coredump map references module '{m['name']}' but no "
-                f"--module-elf {m['name']}=<path> was supplied; skipping.",
-                file=sys.stderr,
-            )
-            continue
-        m["elf"] = elf
-        modules.append(m)
-        print(
-            f"Extracted module '{m['name']}' (sha1={m['sha1']}) from coredump map: "
-            f"text={m['text_addr']} data={m['data_addr']} "
-            f"bss={m['bss_addr']} rodata={m['rodata_addr']}",
-            file=sys.stderr,
-        )
+    core_elf, base = save_core(args.core, args.prog,
+                               core_format=args.core_format, gdb=args.gdb)
+    try:
+        regs = read_registry(core_elf, args.prog, gdb=args.gdb)
+        loaded = []
+        for r in regs:
+            elf = by_name.get(r["name"])
+            if elf:
+                loaded.append({**r, "elf": elf})
+                print(f"# module {r['name']} (sha1 {r['sha1'][:8]}...): symbols loaded",
+                      file=sys.stderr)
+            else:
+                print(f"# module {r['name']} (sha1 {r['sha1'][:8]}...): no --module-elf, skipping",
+                      file=sys.stderr)
 
-    if not modules:
-        print(
-            "WARNING: No modules resolved. Running without module symbols.",
-            file=sys.stderr,
-        )
-
-    operation = "dbg_corefile" if args.operation == "dbg" else "info_corefile"
-    run_espcoredump(args, modules, operation)
+        if args.operation == "dbg":
+            # Interactive esp-coredump session with module symbols pre-loaded
+            # (literal add-symbol-file via --extra-gdbinit-file).
+            gi = write_addsym_gdbinit(loaded)
+            try:
+                cmd = ["esp-coredump", "dbg_corefile", "-t", args.core_format,
+                       "-c", args.core, "--gdb", find_gdb(args.gdb)]
+                if loaded:
+                    cmd += ["--extra-gdbinit-file", gi]
+                cmd.append(args.prog)
+                subprocess.run(cmd)
+            finally:
+                try:
+                    os.remove(gi)
+                except OSError:
+                    pass
+        else:
+            if loaded:
+                print(symbolicated_report(args.core, args.prog, loaded,
+                                          core_format=args.core_format, gdb=args.gdb))
+            else:
+                print(base)
+    finally:
+        try:
+            os.remove(core_elf)
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/esp-crash-server/decode_module_coredump.py
+++ b/esp-crash-server/decode_module_coredump.py
@@ -5,7 +5,9 @@ Decode ESP32 core dumps with dynamically loaded ELF module symbols.
 The on-device module registry is read from the coredump by resolving the
 `s_mod_map` symbol via gdb and printing its fields with plain gdb `printf`
 commands (no gdb-Python: the Espressif toolchain gdb is built without Python
-scripting). Module frames are then symbolicated by handing gdb literal
+scripting). Each record holds the module name, version, its SHA1, and the
+runtime section bases. Module frames are
+then symbolicated by handing gdb literal
 `add-symbol-file <elf> <text> -s .data <data> ...` commands whose addresses are
 the runtime section bases read straight out of the registry.
 
@@ -13,7 +15,7 @@ Flow (host-driven, gdb invoked directly on a saved core ELF):
 
   1. esp-coredump converts the raw dump partition image into a core ELF
      (`--save-core`) and gives us the base panic/backtrace text.
-  2. plain gdb reads `s_mod_map` from the core ELF -> [{name, sha1, sections}].
+  2. plain gdb reads `s_mod_map` from the core ELF -> [{name, version, sha1, sections}].
   3. each module's debug ELF is resolved (server: by sha1; local CLI: by name).
   4. plain gdb re-runs with literal `add-symbol-file` per module and prints a
      module-symbolicated backtrace.
@@ -40,7 +42,7 @@ import tempfile
 SECTION_FIELDS = ("text", "data", "bss", "rodata")
 
 # Delimited line emitted by the gdb registry-read script, one per slot:
-#   MODSLOT|<i>|<name>|<sha1-hex>|<text>|<data>|<bss>|<rodata>
+#   MODSLOT|<i>|<name>|<version>|<sha1-hex>|<text>|<data>|<bss>|<rodata>
 MODSLOT_PREFIX = "MODSLOT|"
 NSLOTS_PREFIX = "NSLOTS="
 
@@ -107,29 +109,31 @@ def _gdb_batch(gdb: str, prog: str, core_elf: str, commands: list[str]) -> str:
 
 
 def _slot_printf(i: int) -> str:
-    """gdb `printf` command that emits one delimited MODSLOT line for slot i,
-    including the 20-byte sha1 as hex and the four section base addresses."""
+    """gdb `printf` command that emits one delimited MODSLOT line for slot i:
+    the module name and version, the 20-byte sha1 as hex, and the four section
+    base addresses."""
     sha = "".join("%02x" for _ in range(20))
     sha_args = ", ".join(f"s_mod_map[{i}].sha1[{b}]" for b in range(20))
     addr_args = ", ".join(f"s_mod_map[{i}].{s}.addr" for s in SECTION_FIELDS)
-    fmt = f"{MODSLOT_PREFIX}{i}|%s|{sha}|%u|%u|%u|%u\\n"
-    return f'printf "{fmt}", s_mod_map[{i}].name, {sha_args}, {addr_args}'
+    fmt = f"{MODSLOT_PREFIX}{i}|%s|%s|{sha}|%u|%u|%u|%u\\n"
+    return (f'printf "{fmt}", s_mod_map[{i}].name, '
+            f's_mod_map[{i}].version, {sha_args}, {addr_args}')
 
 
 def parse_registry_output(text: str) -> list[dict]:
     """Parse MODSLOT lines into occupied-slot records. Best-effort: a slot is
     occupied iff name is non-empty and text.addr != 0. Returns
-    [{name, sha1, text, data, bss, rodata}] with addresses as ints."""
+    [{name, version, sha1, text, data, bss, rodata}] with addresses as ints."""
     mods = []
     for line in text.splitlines():
         line = line.strip()
         if not line.startswith(MODSLOT_PREFIX):
             continue
         parts = line.split("|")
-        # MODSLOT | idx | name | sha1 | text | data | bss | rodata
-        if len(parts) != 8:
+        # MODSLOT | idx | name | version | sha1 | text | data | bss | rodata
+        if len(parts) != 9:
             continue
-        _, _idx, name, sha1, t, d, b, r = parts
+        _, _idx, name, version, sha1, t, d, b, r = parts
         try:
             text_addr, data_addr, bss_addr, rodata_addr = (
                 int(t) & 0xffffffff, int(d) & 0xffffffff,
@@ -140,7 +144,7 @@ def parse_registry_output(text: str) -> list[dict]:
         if not name or text_addr == 0:
             continue  # free or mid-load slot
         mods.append({
-            "name": name, "sha1": sha1,
+            "name": name, "version": version, "sha1": sha1,
             "text": text_addr, "data": data_addr,
             "bss": bss_addr, "rodata": rodata_addr,
         })
@@ -253,13 +257,12 @@ def main():
         loaded = []
         for r in regs:
             elf = by_name.get(r["name"])
+            ident = f"{r['name']} {r['version']} (sha1 {r['sha1'][:8]}...)"
             if elf:
                 loaded.append({**r, "elf": elf})
-                print(f"# module {r['name']} (sha1 {r['sha1'][:8]}...): symbols loaded",
-                      file=sys.stderr)
+                print(f"# module {ident}: symbols loaded", file=sys.stderr)
             else:
-                print(f"# module {r['name']} (sha1 {r['sha1'][:8]}...): no --module-elf, skipping",
-                      file=sys.stderr)
+                print(f"# module {ident}: no --module-elf, skipping", file=sys.stderr)
 
         if args.operation == "dbg":
             # Interactive esp-coredump session with module symbols pre-loaded

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -918,6 +918,7 @@ def show_project_crash(project_name, crash_id):
         )
         modules_for_ui.append({
             "name": e.get("name", ""),
+            "version": e.get("version", ""),
             "sha1_short": sha1[:8],
             "sha1_full": sha1,
             "available": bool(row),
@@ -1056,7 +1057,7 @@ def cron():
             # Read the registry (plain gdb) and resolve module ELFs by sha1.
             regs, loaded, base_text, core_elf, mod_status = \
                 _resolve_modules_for_dump(ldb(), dmp.name, elf.name)
-            last_module_map = [{"name": r["name"], "sha1": r["sha1"]} for r in regs]
+            last_module_map = [{"name": r["name"], "version": r.get("version", ""), "sha1": r["sha1"]} for r in regs]
             try:
                 for line in mod_status:
                     dump += line + "\n"

--- a/esp-crash-server/server.py
+++ b/esp-crash-server/server.py
@@ -244,33 +244,6 @@ def list_projects():
     """Render the landing page listing all projects."""
     return render_template('index.html')
 
-def _module_names_for_dump(crash_dmp):
-    """Best-effort list of module names referenced by a crash dump.
-
-    Used to render the "Modules" tags in the crash list. Parses the on-device
-    module map straight from the dump (independent of whether the crash has
-    been symbolicated yet). Never raises — returns [] on any problem.
-    """
-    if not crash_dmp:
-        return []
-    try:
-        try:
-            decompressed = bz2.decompress(crash_dmp)
-        except IOError:
-            decompressed = crash_dmp
-        dmp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
-                df.write(decompressed)
-                dmp_path = df.name
-            entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
-        finally:
-            if dmp_path:
-                os.unlink(dmp_path)
-        return [e["name"] for e in entries]
-    except Exception:
-        return []
-
 
 @app.route('/projects/<project_name>')
 @login_required
@@ -912,7 +885,7 @@ def show_project_crash(project_name, crash_id):
     auth_where, auth_args = auth_clause("project_auth.github")
     crash = ldb().get_data("""
         SELECT
-            crash.crash_id, crash.date, crash.project_name, crash.device_id, crash.project_ver, crash.crash_dmp, device.ext_device_id, COALESCE(device.alias, '') as device_alias, crash.dump, project_settings.device_url_template
+            crash.crash_id, crash.date, crash.project_name, crash.device_id, crash.project_ver, crash.crash_dmp, device.ext_device_id, COALESCE(device.alias, '') as device_alias, crash.dump, project_settings.device_url_template, crash.module_map
         FROM
             crash
         JOIN
@@ -934,36 +907,21 @@ def show_project_crash(project_name, crash_id):
     # Fetch all elf image data from database that matches this project and version
     elf_images = ldb().get_data("SELECT elf_file_id, date, project_name, project_ver, file_size, project_alias FROM elf_file WHERE project_name = %s AND project_ver = %s ORDER BY date DESC", (crash["project_name"], crash["project_ver"], ))
 
-    # Module map (best-effort; only used to populate the UI block).
+    # Module tags come from the persisted module_map (written at cron time).
+    # Availability is computed live because a module ELF may be uploaded after
+    # the crash was processed.
     modules_for_ui = []
-    try:
-        try:
-            decompressed_dmp = bz2.decompress(crash["crash_dmp"])
-        except IOError:
-            decompressed_dmp = crash["crash_dmp"]
-        dmp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
-                df.write(decompressed_dmp)
-                dmp_path = df.name
-            entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
-        finally:
-            if dmp_path:
-                os.unlink(dmp_path)
-        for e in entries:
-            sha1 = e.get("sha1", "")
-            row = ldb().get_data(
-                "SELECT module_elf_id FROM module_elf WHERE app_sha1 = %s LIMIT 1",
-                (sha1,),
-            )
-            modules_for_ui.append({
-                "name": e["name"],
-                "sha1_short": sha1[:8],
-                "sha1_full": sha1,
-                "available": bool(row),
-            })
-    except Exception as ex:
-        app.logger.warning(f"Module map UI parse failed for crash {crash_id}: {ex}")
+    for e in (crash.get("module_map") or []):
+        sha1 = e.get("sha1", "")
+        row = ldb().get_data(
+            "SELECT module_elf_id FROM module_elf WHERE app_sha1 = %s LIMIT 1", (sha1,)
+        )
+        modules_for_ui.append({
+            "name": e.get("name", ""),
+            "sha1_short": sha1[:8],
+            "sha1_full": sha1,
+            "available": bool(row),
+        })
 
     return render_template('crash.html', crash = crash, elf_images = elf_images, dump = crash["dump"], modules = modules_for_ui)
 
@@ -993,60 +951,57 @@ def refresh_crash(project_name, crash_id):
     return redirect(url_for('show_project_crash', project_name=project_name, crash_id=crash_id))
 
 
-def _resolve_modules_for_dump(db, dump_bytes):
+def _resolve_modules_for_dump(db, dump_path, prog_path):
     """
-    Parse the on-device module map from `dump_bytes`. For every entry, look up
-    the matching debug ELF in module_elf by app_sha1.
+    Read the on-device module registry from the coredump (plain gdb, no Python:
+    the toolchain gdb has no scripting) and resolve each module's debug ELF from
+    module_elf by app_sha1.
 
-    Returns:
-      (resolved_modules, status_lines)
-        resolved_modules: list[dict] enriched with 'elf' = filesystem path to
-                          a temp file containing the uncompressed debug ELF.
-        status_lines: list[str] human-readable annotations, including
-                      "module X (sha1 abcd...): symbols not available" for
-                      missing entries.
+    Returns (regs, loaded, base_text, core_elf, status_lines):
+      regs:    list[{name, sha1, text, data, bss, rodata}] from the registry.
+      loaded:  subset of regs (same dicts) with an extra 'elf' temp-file path,
+               for modules whose symbols were found in module_elf.
+      base_text: esp-coredump's module-unaware panic/backtrace text.
+      core_elf:  path to the saved core ELF (used to symbolicate; owned by caller).
+      status_lines: human-readable annotations ("symbols loaded"/"not available").
+    The caller owns `core_elf` and every loaded['elf'] temp file and must unlink
+    them.
     """
-    import io as _io
-    import tempfile as _tempfile
-
-    # Write dump to a NamedTemporaryFile so the existing parser can read it.
-    dmp_path = None
-    try:
-        with _tempfile.NamedTemporaryFile(suffix=".dmp", delete=False) as df:
-            df.write(dump_bytes)
-            dmp_path = df.name
-        entries = mod_decoder.parse_module_map_from_coredump(dmp_path)
-    except Exception as e:
-        return [], [f"# module map parse error: {e}"]
-    finally:
-        if dmp_path:
-            os.unlink(dmp_path)
-
-    resolved = []
+    core_elf, base_text = mod_decoder.save_core(dump_path, prog_path)
+    loaded = []
     status = []
-    for entry in entries:
-        sha1 = entry.get("sha1", "")
-        rows = db.get_data(
-            "SELECT elf_file FROM module_elf WHERE app_sha1 = %s LIMIT 1",
-            (sha1,),
-        )
-        if not rows:
-            status.append(
-                f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols not available"
+    try:
+        regs = mod_decoder.read_registry(core_elf, prog_path)
+        for entry in regs:
+            sha1 = entry.get("sha1", "")
+            rows = db.get_data(
+                "SELECT elf_file FROM module_elf WHERE app_sha1 = %s LIMIT 1", (sha1,)
             )
-            continue
+            if not rows:
+                status.append(
+                    f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols not available"
+                )
+                continue
+            try:
+                blob = bz2.decompress(rows[0]["elf_file"])
+            except IOError:
+                blob = rows[0]["elf_file"]
+            with tempfile.NamedTemporaryFile(suffix=".elf", delete=False, prefix="mod_") as ef:
+                ef.write(blob)
+            loaded.append({**entry, "elf": ef.name})
+            status.append(f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols loaded")
+    except Exception:
+        for m in loaded:
+            try:
+                os.remove(m["elf"])
+            except OSError:
+                pass
         try:
-            blob = bz2.decompress(rows[0]["elf_file"])
-        except IOError:
-            blob = rows[0]["elf_file"]
-        with _tempfile.NamedTemporaryFile(suffix=".elf", delete=False, prefix="mod_") as ef:
-            ef.write(blob)
-            entry["elf"] = ef.name
-        resolved.append(entry)
-        status.append(
-            f"# module {entry['name']} (sha1 {sha1[:8]}...): symbols loaded"
-        )
-    return resolved, status
+            os.remove(core_elf)
+        except OSError:
+            pass
+        raise
+    return regs, loaded, base_text, core_elf, status
 
 
 @app.route('/cron')
@@ -1083,12 +1038,10 @@ def cron():
             app.logger.info("  No elf_file found")
             continue
 
+        last_module_map = []
         for elf_image in elf_images:
-            # Create temporary files to store crash and elf data
             dmp = tempfile.NamedTemporaryFile(delete=False)
             elf = tempfile.NamedTemporaryFile(delete=False)
-
-            # Decompress crash_dmp and elf_file before writing to temp files
             try:
                 decompressed_crash_dmp = bz2.decompress(crash["crash_dmp"])
             except IOError:
@@ -1097,63 +1050,39 @@ def cron():
                 decompressed_elf_file = bz2.decompress(elf_image["elf_file"])
             except IOError:
                 decompressed_elf_file = elf_image["elf_file"]
+            dmp.write(decompressed_crash_dmp); dmp.close()
+            elf.write(decompressed_elf_file); elf.close()
 
-            # Write decompressed data to temporary files
-            dmp.write(decompressed_crash_dmp)
-            dmp.close()
-            elf.write(decompressed_elf_file)
-            elf.close()
-
-            # Resolve modules referenced by the dump (best-effort; missing
-            # modules are annotated but never block processing).
-            modules, mod_status = _resolve_modules_for_dump(ldb(), decompressed_crash_dmp)
-
-            for line in mod_status:
-                dump += line + "\n"
-
-            gdbinit_path = None
+            # Read the registry (plain gdb) and resolve module ELFs by sha1.
+            regs, loaded, base_text, core_elf, mod_status = \
+                _resolve_modules_for_dump(ldb(), dmp.name, elf.name)
+            last_module_map = [{"name": r["name"], "sha1": r["sha1"]} for r in regs]
             try:
-                # The stored dump is a raw coredump-partition image, so -t raw
-                # parses it directly. When modules are referenced, generate a
-                # gdbinit with their add-symbol-file lines and hand it to
-                # esp-coredump's native --extra-gdbinit-file. The chip is
-                # auto-detected from the self-describing raw image.
-                cmd = ["esp-coredump", "info_corefile", "-t", "raw", "-c", dmp.name]
-                if modules:
-                    with tempfile.NamedTemporaryFile(
-                        mode="w", suffix=".gdbinit", delete=False, prefix="mod_"
-                    ) as gf:
-                        gdbinit_path = gf.name
-                    mod_decoder.generate_gdbinit(modules, gdbinit_path)
-                    cmd += ["--extra-gdbinit-file", gdbinit_path]
-                cmd.append(elf.name)
-                p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                dump += (p.stdout + p.stderr).decode("utf-8")
+                for line in mod_status:
+                    dump += line + "\n"
+                if loaded:
+                    # Re-run esp-coredump with a literal add-symbol-file gdbinit so
+                    # its full report resolves the module frames inline.
+                    dump += mod_decoder.symbolicated_report(dmp.name, elf.name, loaded)
+                else:
+                    dump += base_text
             finally:
-                # Clean up temp module ELF files and the generated gdbinit.
-                for m in modules:
+                for m in loaded:
                     try:
                         os.remove(m["elf"])
                     except OSError:
                         pass
-                if gdbinit_path:
+                for path in (core_elf, dmp.name, elf.name):
                     try:
-                        os.remove(gdbinit_path)
+                        os.remove(path)
                     except OSError:
                         pass
 
-            # Delete temporary files
-            os.unlink(dmp.name)
-            os.unlink(elf.name)
-
-        # Update the dump field in the database with the crash dump info.
-        # Also persist the referenced module names now (at processing time) so the
-        # crash-list view can render its "Modules" tags without parsing every
-        # coredump on each page load.
-        module_names = _module_names_for_dump(crash["crash_dmp"])
+        from psycopg2.extras import Json
+        module_names = [m["name"] for m in last_module_map]
         c.execute(
-            "UPDATE crash SET dump = %s, module_names = %s WHERE crash_id = %s",
-            (dump, module_names, crash["crash_id"]),
+            "UPDATE crash SET dump = %s, module_names = %s, module_map = %s WHERE crash_id = %s",
+            (dump, module_names, Json(last_module_map), crash["crash_id"]),
         )
         conn.commit()
         app.logger.info("Updated crash {} (modules: {})".format(crash["crash_id"], module_names))
@@ -1410,30 +1339,45 @@ def download_crash(crash_id):
         dmp.write(decompressed_crash_dmp)
         dmp.close()
         zip_file.write(dmp.name,  arcname="crash_{}/crash_{}.dmp".format(crash_id, crash_id))
-        os.unlink(dmp.name)
 
-        # Resolve any dynamically-loaded modules referenced by the dump so the
-        # package can ship their debug ELFs and a ready-to-use gdbinit. Each
-        # resolved entry's debug ELF is written to a temp file (m["elf"]); clean
-        # those up in the finally below.
-        resolved, mod_status = _resolve_modules_for_dump(ldb(), decompressed_crash_dmp)
+        # Read the registry and resolve module ELFs so the package can ship the
+        # module debug ELFs plus a generated gdbinit with literal add-symbol-file
+        # lines (no gdb-Python needed). Reading needs the program ELF, so use the
+        # first (most recent) elf_image.
+        prog_tmp = None
+        loaded = []
+        core_elf = None
+        mod_status = []
         try:
-            if resolved:
-                # Ship each module's debug ELF and remember the relative path the
-                # gdbinit should reference (valid once the script cd's into the
-                # package dir).
-                for m in resolved:
+            if elf_images:
+                try:
+                    first = bz2.decompress(elf_images[0]["elf_file"])
+                except IOError:
+                    first = elf_images[0]["elf_file"]
+                with tempfile.NamedTemporaryFile(suffix=".elf", delete=False, prefix="prog_") as pf:
+                    pf.write(first)
+                    prog_tmp = pf.name
+                _regs, loaded, _base, core_elf, mod_status = \
+                    _resolve_modules_for_dump(ldb(), dmp.name, prog_tmp)
+            gdbinit_lines = []
+            if loaded:
+                for m in loaded:
                     safe = re.sub(r'[^A-Za-z0-9._-]', '_', m["name"])
-                    zip_file.write(m["elf"], arcname="crash_{}/modules/{}.elf".format(crash_id, safe))
-                    m["elf_display"] = "modules/{}.elf".format(safe)
-                # Pre-generate the gdbinit: reads each m["elf"] for the load base,
-                # emits the relative m["elf_display"] paths.
-                gi = tempfile.NamedTemporaryFile(mode="w", suffix=".gdbinit", delete=False)
-                gi.close()
-                mod_decoder.generate_gdbinit(resolved, gi.name)
-                zip_file.write(gi.name, arcname="crash_{}/module_symbols.gdbinit".format(crash_id))
-                os.unlink(gi.name)
-                # Note any referenced modules whose symbols were not uploaded.
+                    arc = "modules/{}.elf".format(safe)
+                    zip_file.write(m["elf"], arcname="crash_{}/{}".format(crash_id, arc))
+                    gdbinit_lines.append(
+                        "add-symbol-file {arc} {text:#x} -s .data {data:#x} "
+                        "-s .bss {bss:#x} -s .rodata {rodata:#x}".format(
+                            arc=arc, text=m["text"], data=m["data"],
+                            bss=m["bss"], rodata=m["rodata"])
+                    )
+                zip_file.writestr(
+                    "crash_{}/module_symbols.gdbinit".format(crash_id),
+                    "# Literal add-symbol-file lines for this crash's modules.\n"
+                    "# Run gdb from this directory so the relative module paths\n"
+                    "# resolve. No gdb-Python required.\n"
+                    + "\n".join(gdbinit_lines) + "\n",
+                )
                 missing = [s for s in mod_status if "symbols not available" in s]
                 if missing:
                     zip_file.writestr(
@@ -1462,13 +1406,9 @@ def download_crash(crash_id):
 
                 core_arc = "crash_{}.dmp".format(crash_id)
                 elf_arc = "elf_{}.elf".format(elf_image["elf_file_id"])
-                lines = ["#!/bin/bash"]
-                if resolved:
-                    lines.append("# Launches esp-coredump with module symbols pre-loaded.")
-                # cd into the package dir so the relative .dmp/.elf/gdbinit paths resolve.
-                lines.append('cd "$(dirname "$0")"')
-                lines.append(". $ESP_IDF/export.sh")
-                if resolved:
+                lines = ["#!/bin/bash", 'cd "$(dirname "$0")"', ". $ESP_IDF/export.sh"]
+                if gdbinit_lines:
+                    lines.insert(1, "# Launches esp-coredump with module symbols pre-loaded.")
                     lines.append(
                         "exec esp-coredump dbg_corefile -t raw --core {} \\\n"
                         "    --extra-gdbinit-file module_symbols.gdbinit {}".format(core_arc, elf_arc)
@@ -1482,12 +1422,25 @@ def download_crash(crash_id):
                 zip_file.write(script.name, arcname="crash_{}/elf_{}.sh".format(crash_id, elf_image["elf_file_id"]))
                 os.unlink(script.name)
         finally:
-            # Clean up the temp module debug ELFs written by _resolve_modules_for_dump.
-            for m in resolved:
+            for m in loaded:
                 try:
                     os.remove(m["elf"])
                 except OSError:
                     pass
+            if core_elf:
+                try:
+                    os.remove(core_elf)
+                except OSError:
+                    pass
+            if prog_tmp:
+                try:
+                    os.remove(prog_tmp)
+                except OSError:
+                    pass
+            try:
+                os.remove(dmp.name)
+            except OSError:
+                pass
 
     # Send zip file
     status = send_file(zipf.name, mimetype='application/zip', as_attachment=True, download_name="crash_{}.zip".format(crash_id))

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -90,6 +90,11 @@
                 </span>
                 {% endif %}
             </div>
+            {% if m.version %}
+            <div class="mt-2 text-xs text-gray-600 font-mono break-all">
+                version {{ m.version }}
+            </div>
+            {% endif %}
             <div class="mt-2 text-xs text-gray-500 font-mono break-all">
                 sha1 {{ m.sha1_full }}
             </div>

--- a/esp-crash-server/test_decode_module_coredump.py
+++ b/esp-crash-server/test_decode_module_coredump.py
@@ -1,0 +1,95 @@
+import decode_module_coredump as d
+
+
+def test_parse_registry_output_reads_occupied_slot():
+    out = (
+        "some gdb banner\n"
+        "MODSLOT|0|ems_goodwe|907577e48f4fe8b69a2e92468dbade2d72a5ea28|"
+        "1076484860|1073651168|1073651216|1062290960\n"
+        "MODSLOT|1||0|0|0|0\n"  # free slot
+    )
+    mods = d.parse_registry_output(out)
+    assert mods == [{
+        "name": "ems_goodwe",
+        "sha1": "907577e48f4fe8b69a2e92468dbade2d72a5ea28",
+        "text": 1076484860, "data": 1073651168,
+        "bss": 1073651216, "rodata": 1062290960,
+    }]
+
+
+def test_parse_registry_output_skips_free_and_midload_slots():
+    out = (
+        "MODSLOT|0||0|0|0|0\n"               # free: empty name
+        "MODSLOT|1|loading|ab|0|10|20|30\n"  # mid-load: text.addr == 0
+    )
+    assert d.parse_registry_output(out) == []
+
+
+def test_parse_registry_output_no_slots_returns_empty():
+    assert d.parse_registry_output("nothing here\n") == []
+
+
+def test_parse_registry_output_ignores_malformed_lines():
+    out = "MODSLOT|0|x\nMODSLOT|0|x|aa|notanint|0|0|0\n"
+    assert d.parse_registry_output(out) == []
+
+
+def test_parse_elf_map_arg_splits_name_path():
+    assert d.parse_elf_map_arg("ems-goodwe=/t/x.app.elf") == ("ems-goodwe", "/t/x.app.elf")
+
+
+def test_parse_elf_map_arg_keeps_equals_in_path():
+    assert d.parse_elf_map_arg("m=/t/a=b.elf") == ("m", "/t/a=b.elf")
+
+
+def test_parse_elf_map_arg_requires_equals():
+    try:
+        d.parse_elf_map_arg("no-equals")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for spec without '='")
+
+
+def test_addsym_commands_emits_literal_hex_sections():
+    loaded = [{
+        "name": "ems_goodwe", "sha1": "aa", "elf": "/t/mod.elf",
+        "text": 0x4029dafc, "data": 0x3ffb3260,
+        "bss": 0x3ffb3290, "rodata": 0x3f4264d0,
+    }]
+    cmds = d.addsym_commands(loaded)
+    assert cmds == [
+        "add-symbol-file /t/mod.elf 0x4029dafc -s .data 0x3ffb3260 "
+        "-s .bss 0x3ffb3290 -s .rodata 0x3f4264d0"
+    ]
+
+
+def test_addsym_commands_empty_for_no_modules():
+    assert d.addsym_commands([]) == []
+
+
+def test_write_addsym_gdbinit_writes_literal_lines():
+    import os
+    loaded = [{
+        "name": "m", "sha1": "aa", "elf": "/t/m.elf",
+        "text": 0x10, "data": 0x20, "bss": 0x30, "rodata": 0x40,
+    }]
+    p = d.write_addsym_gdbinit(loaded)
+    try:
+        with open(p) as f:
+            content = f.read()
+        assert content == (
+            "add-symbol-file /t/m.elf 0x10 -s .data 0x20 "
+            "-s .bss 0x30 -s .rodata 0x40\n"
+        )
+    finally:
+        os.unlink(p)
+
+
+def test_write_addsym_gdbinit_empty_for_no_modules():
+    import os
+    p = d.write_addsym_gdbinit([])
+    try:
+        with open(p) as f:
+            assert f.read() == ""
+    finally:
+        os.unlink(p)

--- a/esp-crash-server/test_decode_module_coredump.py
+++ b/esp-crash-server/test_decode_module_coredump.py
@@ -4,13 +4,14 @@ import decode_module_coredump as d
 def test_parse_registry_output_reads_occupied_slot():
     out = (
         "some gdb banner\n"
-        "MODSLOT|0|ems_goodwe|907577e48f4fe8b69a2e92468dbade2d72a5ea28|"
+        "MODSLOT|0|ems_goodwe|1560-a6f50c32|907577e48f4fe8b69a2e92468dbade2d72a5ea28|"
         "1076484860|1073651168|1073651216|1062290960\n"
-        "MODSLOT|1||0|0|0|0\n"  # free slot
+        "MODSLOT|1||||0|0|0|0\n"  # free slot: empty name
     )
     mods = d.parse_registry_output(out)
     assert mods == [{
         "name": "ems_goodwe",
+        "version": "1560-a6f50c32",
         "sha1": "907577e48f4fe8b69a2e92468dbade2d72a5ea28",
         "text": 1076484860, "data": 1073651168,
         "bss": 1073651216, "rodata": 1062290960,
@@ -19,8 +20,8 @@ def test_parse_registry_output_reads_occupied_slot():
 
 def test_parse_registry_output_skips_free_and_midload_slots():
     out = (
-        "MODSLOT|0||0|0|0|0\n"               # free: empty name
-        "MODSLOT|1|loading|ab|0|10|20|30\n"  # mid-load: text.addr == 0
+        "MODSLOT|0||||0|0|0|0\n"                   # free: empty name
+        "MODSLOT|1|loading|1.0|ab|0|10|20|30\n"   # mid-load: text.addr == 0
     )
     assert d.parse_registry_output(out) == []
 
@@ -30,7 +31,7 @@ def test_parse_registry_output_no_slots_returns_empty():
 
 
 def test_parse_registry_output_ignores_malformed_lines():
-    out = "MODSLOT|0|x\nMODSLOT|0|x|aa|notanint|0|0|0\n"
+    out = "MODSLOT|0|x\nMODSLOT|0|x|v|aa|notanint|0|0|0\n"
     assert d.parse_registry_output(out) == []
 
 
@@ -52,7 +53,7 @@ def test_parse_elf_map_arg_requires_equals():
 
 def test_addsym_commands_emits_literal_hex_sections():
     loaded = [{
-        "name": "ems_goodwe", "sha1": "aa", "elf": "/t/mod.elf",
+        "name": "ems_goodwe", "version": "1.0", "sha1": "aa", "elf": "/t/mod.elf",
         "text": 0x4029dafc, "data": 0x3ffb3260,
         "bss": 0x3ffb3290, "rodata": 0x3f4264d0,
     }]
@@ -70,7 +71,7 @@ def test_addsym_commands_empty_for_no_modules():
 def test_write_addsym_gdbinit_writes_literal_lines():
     import os
     loaded = [{
-        "name": "m", "sha1": "aa", "elf": "/t/m.elf",
+        "name": "m", "version": "1.0", "sha1": "aa", "elf": "/t/m.elf",
         "text": 0x10, "data": 0x20, "bss": 0x30, "rodata": 0x40,
     }]
     p = d.write_addsym_gdbinit(loaded)


### PR DESCRIPTION
rely on the coredump symbols of  `s_mod_map` struct to find the loaded modules and their information, use them for decoding the coredump