### PR TITLE
Auto-summarize and tag crashes with Claude via the MCP connector

### DIFF
--- a/esp-crash-server/alembic/versions/6beade548d43_add_crash_ai_summary.py
+++ b/esp-crash-server/alembic/versions/6beade548d43_add_crash_ai_summary.py
@@ -1,0 +1,28 @@
+"""add crash ai_summary
+
+Revision ID: 6beade548d43
+Revises: cea7c0eff075
+Create Date: 2026-08-13 14:01:53.910116
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6beade548d43'
+down_revision: Union[str, Sequence[str], None] = 'cea7c0eff075'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('crash', sa.Column('ai_summary', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('crash', 'ai_summary')

--- a/esp-crash-server/app/ai_tagging.py
+++ b/esp-crash-server/app/ai_tagging.py
@@ -1,0 +1,62 @@
+"""Automated crash summary + tagging via Claude's remote MCP connector.
+
+Calls the Anthropic Messages API with the app's own MCP server declared as a
+remote tool source (`mcp_servers` + an `mcp_toolset` tool) - Claude fetches
+crash context and applies tags itself, server-side, inside one API call, via
+the service-token identity in mcp_app/auth.py. Kept out of cron.py so
+`app.ai_tagging.summarize_and_tag` is a single, stable mock target for tests,
+matching how app.decode is split out for cron's symbolication step.
+"""
+from anthropic import Anthropic
+from flask import current_app
+from sqlalchemy import update
+
+from .models import Crash, db
+
+MCP_BETA = "mcp-client-2025-11-20"
+MODEL = "claude-sonnet-5"
+
+
+def summarize_and_tag(crash_id, project_name):
+    """Ask Claude to summarize this crash and apply appropriate tags via the
+    app's own MCP server, then store the summary. Raises on any failure -
+    callers should catch, log, and move on: ai_summary stays NULL, so the
+    crash is picked up again on a later cron tick."""
+    client = Anthropic(api_key=current_app.config["ANTHROPIC_API_KEY"])
+    mcp_url = current_app.config["MCP_PUBLIC_URL"].rstrip("/") + "/mcp"
+
+    response = client.beta.messages.create(
+        model=MODEL,
+        max_tokens=4096,
+        betas=[MCP_BETA],
+        mcp_servers=[{
+            "type": "url",
+            "name": "esp-crash",
+            "url": mcp_url,
+            "authorization_token": current_app.config["MCP_SERVICE_TOKEN"],
+        }],
+        tools=[{"type": "mcp_toolset", "mcp_server_name": "esp-crash"}],
+        messages=[{
+            "role": "user",
+            "content": (
+                f"Crash {crash_id} in project '{project_name}' was just symbolicated. "
+                "Use the esp-crash MCP tools: call get_crash to read its details, and "
+                "list_tags to see this project's existing tags. Write a short (2-3 "
+                "sentence) plain-English summary of what the crash is and its likely "
+                "cause. Then call add_tag_to_crash once per tag that fits - reuse an "
+                "existing tag whenever one applies, and only create a new tag when "
+                "nothing existing fits. Do not remove any existing tags. Respond with "
+                "only the summary text, nothing else."
+            ),
+        }],
+    )
+
+    summary = "".join(
+        block.text for block in response.content if block.type == "text"
+    ).strip()
+
+    db.session.execute(
+        update(Crash).where(Crash.crash_id == crash_id).values(ai_summary=summary)
+    )
+    db.session.commit()
+    return summary

--- a/esp-crash-server/app/config.py
+++ b/esp-crash-server/app/config.py
@@ -49,3 +49,11 @@ def configure_app(app):
     app.config["EXTERNAL_URL"] = os.environ.get("EXTERNAL_URL", "")
     if not app.config["EXTERNAL_URL"]:
         app.logger.warning("EXTERNAL_URL not set - Slack URLs may not work properly")
+
+    # Cron-driven AI summarize+tag step (app/ai_tagging.py). All optional -
+    # if MCP_SERVICE_GITHUB_USER is unset, cron.py skips the step entirely
+    # (no project can match an empty ACL join).
+    app.config["ANTHROPIC_API_KEY"] = os.environ.get("ANTHROPIC_API_KEY", "")
+    app.config["MCP_PUBLIC_URL"] = os.environ.get("MCP_PUBLIC_URL", "")
+    app.config["MCP_SERVICE_TOKEN"] = os.environ.get("MCP_SERVICE_TOKEN", "")
+    app.config["MCP_SERVICE_GITHUB_USER"] = os.environ.get("MCP_SERVICE_GITHUB_USER", "")

--- a/esp-crash-server/app/config.py
+++ b/esp-crash-server/app/config.py
@@ -51,8 +51,9 @@ def configure_app(app):
         app.logger.warning("EXTERNAL_URL not set - Slack URLs may not work properly")
 
     # Cron-driven AI summarize+tag step (app/ai_tagging.py). All optional -
-    # if MCP_SERVICE_GITHUB_USER is unset, cron.py skips the step entirely
-    # (no project can match an empty ACL join).
+    # cron.py requires every one of these to be set before attempting the
+    # step; a missing/empty value cleanly skips it rather than retrying a
+    # doomed API call every tick.
     app.config["ANTHROPIC_API_KEY"] = os.environ.get("ANTHROPIC_API_KEY", "")
     app.config["MCP_PUBLIC_URL"] = os.environ.get("MCP_PUBLIC_URL", "")
     app.config["MCP_SERVICE_TOKEN"] = os.environ.get("MCP_SERVICE_TOKEN", "")

--- a/esp-crash-server/app/models.py
+++ b/esp-crash-server/app/models.py
@@ -38,6 +38,7 @@ class Crash(db.Model):
     dump = db.Column(db.Text)
     module_names = db.Column(ARRAY(db.Text))
     module_map = db.Column(JSONB)
+    ai_summary = db.Column(db.Text)
 
 
 class ElfFile(db.Model):

--- a/esp-crash-server/app/routes/crashes.py
+++ b/esp-crash-server/app/routes/crashes.py
@@ -33,7 +33,7 @@ def show_project_crash(project_name, crash_id):
             Crash.crash_id, Crash.date, Crash.project_name, Crash.device_id,
             Crash.project_ver, Crash.crash_dmp, Device.ext_device_id,
             func.coalesce(Device.alias, "").label("device_alias"), Crash.dump,
-            ProjectSettings.device_url_template, Crash.module_map,
+            ProjectSettings.device_url_template, Crash.module_map, Crash.ai_summary,
         )
         .select_from(Crash)
         .join(ProjectAuth, Crash.project_name == ProjectAuth.project_name)

--- a/esp-crash-server/app/routes/cron.py
+++ b/esp-crash-server/app/routes/cron.py
@@ -16,7 +16,8 @@ from sqlalchemy import func, select, update
 
 import decode_module_coredump as mod_decoder
 from .. import decode
-from ..models import Crash, ElfFile, ProjectSlackIntegration, ProjectWebhook, db
+from ..ai_tagging import summarize_and_tag
+from ..models import Crash, ElfFile, ProjectAuth, ProjectSlackIntegration, ProjectWebhook, db
 from ..rendering import external_url_for
 
 
@@ -262,6 +263,24 @@ def cron():
         else:
             current_app.logger.info(f"No Slack integrations found for project {project_name}")
 
+    # AI summary + tagging: a second, independent pass with its own retry
+    # gate (ai_summary IS NULL), scoped to projects that have explicitly
+    # granted the service identity ACL access - see app/ai_tagging.py.
+    service_user = current_app.config.get("MCP_SERVICE_GITHUB_USER")
+    if service_user:
+        ai_crashes = db.session.execute(
+            select(Crash.crash_id, Crash.project_name)
+            .join(ProjectAuth, (Crash.project_name == ProjectAuth.project_name)
+                                & (ProjectAuth.github == service_user))
+            .where(Crash.dump.is_not(None), Crash.ai_summary.is_(None))
+            .limit(10)
+        ).mappings().all()
+        for crash in ai_crashes:
+            try:
+                summarize_and_tag(crash["crash_id"], crash["project_name"])
+                current_app.logger.info(f"AI-summarized crash {crash['crash_id']}")
+            except Exception as e:
+                current_app.logger.error(f"AI summarize/tag failed for crash {crash['crash_id']}: {e}")
 
     # return just a 200 OK
     return "OK\n", 200

--- a/esp-crash-server/app/routes/cron.py
+++ b/esp-crash-server/app/routes/cron.py
@@ -265,9 +265,23 @@ def cron():
 
     # AI summary + tagging: a second, independent pass with its own retry
     # gate (ai_summary IS NULL), scoped to projects that have explicitly
-    # granted the service identity ACL access - see app/ai_tagging.py.
+    # granted the service identity ACL access - see app/ai_tagging.py. Gate
+    # on every required config value, not just MCP_SERVICE_GITHUB_USER - a
+    # partially-configured deployment would otherwise retry a doomed API
+    # call every tick instead of a clean, informative no-op.
     service_user = current_app.config.get("MCP_SERVICE_GITHUB_USER")
-    if service_user:
+    ai_configured = bool(
+        service_user
+        and current_app.config.get("ANTHROPIC_API_KEY")
+        and current_app.config.get("MCP_PUBLIC_URL")
+        and current_app.config.get("MCP_SERVICE_TOKEN")
+    )
+    if service_user and not ai_configured:
+        current_app.logger.warning(
+            "MCP_SERVICE_GITHUB_USER is set but one of ANTHROPIC_API_KEY / "
+            "MCP_PUBLIC_URL / MCP_SERVICE_TOKEN is not - skipping AI summarize/tag step"
+        )
+    if ai_configured:
         ai_crashes = db.session.execute(
             select(Crash.crash_id, Crash.project_name)
             .join(ProjectAuth, (Crash.project_name == ProjectAuth.project_name)

--- a/esp-crash-server/mcp_app/auth.py
+++ b/esp-crash-server/mcp_app/auth.py
@@ -42,11 +42,22 @@ _AUTH_CODE_TTL = 600  # seconds
 class GitHubOAuthProvider(
     OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]
 ):
-    def __init__(self, github_client_id, github_client_secret, callback_url, mcp_scope="esp-crash"):
+    def __init__(
+        self, github_client_id, github_client_secret, callback_url, mcp_scope="esp-crash",
+        service_token=None, service_github_user=None,
+    ):
         self.github_client_id = github_client_id
         self.github_client_secret = github_client_secret
         self.callback_url = callback_url  # {MCP_PUBLIC_URL}/github/callback
         self.mcp_scope = mcp_scope
+        # Optional non-interactive path for trusted automation (e.g. the cron
+        # worker's Claude-driven summarize/tag call) - a static shared secret
+        # standing in for a browser-driven GitHub login. subject is just a
+        # project_auth.github string like any other; it's never validated
+        # against a real GitHub account, so the caller must be explicitly
+        # granted project_auth access like any other user.
+        self.service_token = service_token
+        self.service_github_user = service_github_user
 
         self.clients: dict[str, OAuthClientInformationFull] = {}
         self.auth_codes: dict[str, AuthorizationCode] = {}
@@ -159,6 +170,11 @@ class GitHubOAuthProvider(
     # ---- resource-server side ---------------------------------------------
 
     async def load_access_token(self, token):
+        if self.service_token and token == self.service_token:
+            return AccessToken(
+                token=token, client_id="service", scopes=[self.mcp_scope],
+                expires_at=None, subject=self.service_github_user,
+            )
         at = self.access_tokens.get(token)
         if at is None:
             return None

--- a/esp-crash-server/mcp_app/server.py
+++ b/esp-crash-server/mcp_app/server.py
@@ -60,6 +60,8 @@ def build_app():
         github_client_secret=github_client_secret,
         callback_url=f"{public_url}/github/callback",
         mcp_scope=MCP_SCOPE,
+        service_token=os.environ.get("MCP_SERVICE_TOKEN"),
+        service_github_user=os.environ.get("MCP_SERVICE_GITHUB_USER"),
     )
 
     mcp = FastMCP(

--- a/esp-crash-server/mcp_app/tools.py
+++ b/esp-crash-server/mcp_app/tools.py
@@ -89,7 +89,7 @@ def list_crashes(github_user, project_name=None, search=None, tag_id=None, limit
     rows = db.session.execute(
         select(
             Crash.crash_id, Crash.date, Crash.project_name, Crash.project_ver,
-            Crash.device_id, Crash.module_names,
+            Crash.device_id, Crash.module_names, Crash.ai_summary,
             Device.ext_device_id, Device.alias,
         )
         .select_from(Crash)
@@ -115,7 +115,7 @@ def get_crash(github_user, crash_id):
         select(
             Crash.crash_id, Crash.date, Crash.project_name, Crash.project_ver,
             Crash.device_id, Device.ext_device_id, Device.alias,
-            Crash.dump, Crash.module_map, Crash.module_names,
+            Crash.dump, Crash.module_map, Crash.module_names, Crash.ai_summary,
         )
         .select_from(Crash)
         .join(ProjectAuth, Crash.project_name == ProjectAuth.project_name)

--- a/esp-crash-server/requirements.txt
+++ b/esp-crash-server/requirements.txt
@@ -10,3 +10,4 @@ flask_sqlalchemy
 slack-sdk
 mcp==1.28.1
 uvicorn
+anthropic

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -72,6 +72,12 @@
     </div>
 </div>
 
+{% if crash.ai_summary %}
+<div class="w-5/6 mt-4 p-4 bg-indigo-50 border border-indigo-100 rounded-lg text-sm text-slate-700 italic">
+    {{ crash.ai_summary }}
+</div>
+{% endif %}
+
 <div class="w-5/6 mt-4">
     <div class="flex flex-wrap items-center gap-2">
         {% for t in crash.tags %}

--- a/esp-crash-server/tests/helpers.py
+++ b/esp-crash-server/tests/helpers.py
@@ -25,12 +25,12 @@ def create_device(db_conn, ext_device_id, alias=None):
         return cur.fetchone()[0]
 
 
-def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None):
+def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None, ai_summary=None):
     with db_conn.cursor() as cur:
         cur.execute(
-            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump)
-               VALUES (NOW(), %s, %s, %s, %s, %s) RETURNING crash_id""",
-            (project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump),
+            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump, ai_summary)
+               VALUES (NOW(), %s, %s, %s, %s, %s, %s) RETURNING crash_id""",
+            (project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump, ai_summary),
         )
         return cur.fetchone()[0]
 

--- a/esp-crash-server/tests/test_ai_tagging.py
+++ b/esp-crash-server/tests/test_ai_tagging.py
@@ -1,0 +1,72 @@
+"""Tests for app/ai_tagging.py - mocks the anthropic client entirely (no
+real API calls), verifying the request shape and that the returned summary
+text is persisted."""
+from app import ai_tagging
+
+import helpers
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.type = "text"
+        self.text = text
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self.content = [_FakeTextBlock(text)]
+
+
+class _FakeMessages:
+    def __init__(self, response, calls):
+        self._response = response
+        self._calls = calls
+
+    def create(self, **kwargs):
+        self._calls.append(kwargs)
+        return self._response
+
+
+class _FakeBeta:
+    def __init__(self, response, calls):
+        self.messages = _FakeMessages(response, calls)
+
+
+class _FakeAnthropicClient:
+    def __init__(self, response, calls):
+        self.beta = _FakeBeta(response, calls)
+
+
+def test_summarize_and_tag_writes_summary_and_calls_mcp_connector(app, db_conn, monkeypatch):
+    calls = []
+    summary_text = "Stack overflow in task X caused by a large local buffer."
+    fake_response = _FakeResponse(summary_text)
+    monkeypatch.setattr(
+        ai_tagging, "Anthropic",
+        lambda api_key=None: _FakeAnthropicClient(fake_response, calls),
+    )
+
+    helpers.create_project(db_conn, "proj-ai-1", github_user="alice")
+    device_id = helpers.create_device(db_conn, "dev-ai-1")
+    crash_id = helpers.create_crash(db_conn, "proj-ai-1", "1.0", device_id, dump="symbolicated text")
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(crash_id, "proj-ai-1")
+
+    assert result == summary_text
+    assert len(calls) == 1
+    kwargs = calls[0]
+    assert kwargs["model"] == "claude-sonnet-5"
+    assert kwargs["betas"] == ["mcp-client-2025-11-20"]
+    assert kwargs["mcp_servers"][0]["url"] == "https://mcp-esp-crash.example/mcp"
+    assert kwargs["mcp_servers"][0]["authorization_token"] == "svc-token"
+    assert kwargs["tools"] == [{"type": "mcp_toolset", "mcp_server_name": "esp-crash"}]
+    assert str(crash_id) in kwargs["messages"][0]["content"]
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
+        assert cur.fetchone()[0] == summary_text

--- a/esp-crash-server/tests/test_cron.py
+++ b/esp-crash-server/tests/test_cron.py
@@ -103,6 +103,16 @@ def test_cron_sends_slack_notification(client, db_conn, monkeypatch):
     assert posted[0]["channel"] == "C123"
 
 
+def _configure_ai(app):
+    """Set every config value app/routes/cron.py requires before it will
+    attempt the AI summarize/tag step - see test_cron_ai_summary_requires_full_config
+    for what happens when only some of these are set."""
+    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+
 def test_cron_ai_summary_scoped_to_granted_projects(client, db_conn, monkeypatch, app):
     from app import decode
     from app.routes import cron
@@ -110,7 +120,7 @@ def test_cron_ai_summary_scoped_to_granted_projects(client, db_conn, monkeypatch
     monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
     calls = []
     monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append((crash_id, project_name)))
-    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+    _configure_ai(app)
 
     device_id = helpers.create_device(db_conn, "dev-cron-ai-1")
     helpers.create_project(db_conn, "proj-cron-ai-granted", github_user="esp-crash-bot")
@@ -133,7 +143,7 @@ def test_cron_ai_summary_skips_already_summarized(client, db_conn, monkeypatch, 
     monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
     calls = []
     monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append(crash_id))
-    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+    _configure_ai(app)
 
     device_id = helpers.create_device(db_conn, "dev-cron-ai-2")
     helpers.create_project(db_conn, "proj-cron-ai-done", github_user="esp-crash-bot")
@@ -158,7 +168,7 @@ def test_cron_ai_summary_failure_is_logged_and_skipped(client, db_conn, monkeypa
         raise RuntimeError("boom")
 
     monkeypatch.setattr(cron, "summarize_and_tag", failing_summarize)
-    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+    _configure_ai(app)
 
     device_id = helpers.create_device(db_conn, "dev-cron-ai-3")
     helpers.create_project(db_conn, "proj-cron-ai-fail", github_user="esp-crash-bot")
@@ -172,6 +182,62 @@ def test_cron_ai_summary_failure_is_logged_and_skipped(client, db_conn, monkeypa
     with db_conn.cursor() as cur:
         cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
         assert cur.fetchone()[0] is None
+
+
+def test_cron_ai_summary_requires_full_config(client, db_conn, monkeypatch, app):
+    """MCP_SERVICE_GITHUB_USER alone isn't enough - a partially configured
+    deployment (e.g. ANTHROPIC_API_KEY not yet set) must not call the AI
+    step at all, let alone crash or spin retrying a doomed call."""
+    from app import decode
+    from app.routes import cron
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
+    calls = []
+    monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append(crash_id))
+
+    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+    app.config["ANTHROPIC_API_KEY"] = ""
+    app.config["MCP_PUBLIC_URL"] = ""
+    app.config["MCP_SERVICE_TOKEN"] = ""
+
+    device_id = helpers.create_device(db_conn, "dev-cron-ai-4")
+    helpers.create_project(db_conn, "proj-cron-ai-partial", github_user="esp-crash-bot")
+    helpers.create_elf_file(db_conn, "proj-cron-ai-partial", "1.0")
+    helpers.create_crash(db_conn, "proj-cron-ai-partial", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+    assert resp.data == b"OK\n"
+    assert calls == []
+
+
+def test_cron_ai_summary_no_op_when_entirely_unconfigured(client, db_conn, monkeypatch, app):
+    """The default, out-of-the-box state (nobody has set any of the four AI
+    env vars): cron must behave exactly as it did before this feature -
+    normal symbolication, no AI calls, no errors."""
+    from app import decode
+    from app.routes import cron
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
+    calls = []
+    monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append(crash_id))
+
+    for key in ("MCP_SERVICE_GITHUB_USER", "ANTHROPIC_API_KEY", "MCP_PUBLIC_URL", "MCP_SERVICE_TOKEN"):
+        app.config[key] = ""
+
+    device_id = helpers.create_device(db_conn, "dev-cron-ai-5")
+    helpers.create_elf_file(db_conn, "proj-cron-ai-unconfigured", "1.0")
+    crash_id = helpers.create_crash(db_conn, "proj-cron-ai-unconfigured", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+    assert resp.data == b"OK\n"
+    assert calls == []
+
+    # symbolication itself is unaffected
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT dump FROM crash WHERE crash_id = %s", (crash_id,))
+        assert "base panic text" in cur.fetchone()[0]
 
 
 @pytest.mark.integration

--- a/esp-crash-server/tests/test_cron.py
+++ b/esp-crash-server/tests/test_cron.py
@@ -103,6 +103,77 @@ def test_cron_sends_slack_notification(client, db_conn, monkeypatch):
     assert posted[0]["channel"] == "C123"
 
 
+def test_cron_ai_summary_scoped_to_granted_projects(client, db_conn, monkeypatch, app):
+    from app import decode
+    from app.routes import cron
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
+    calls = []
+    monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append((crash_id, project_name)))
+    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+
+    device_id = helpers.create_device(db_conn, "dev-cron-ai-1")
+    helpers.create_project(db_conn, "proj-cron-ai-granted", github_user="esp-crash-bot")
+    helpers.create_elf_file(db_conn, "proj-cron-ai-granted", "1.0")
+    granted_crash = helpers.create_crash(db_conn, "proj-cron-ai-granted", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    # No project_auth grant for esp-crash-bot on this project - must be skipped.
+    helpers.create_elf_file(db_conn, "proj-cron-ai-ungranted", "1.0")
+    helpers.create_crash(db_conn, "proj-cron-ai-ungranted", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+    assert calls == [(granted_crash, "proj-cron-ai-granted")]
+
+
+def test_cron_ai_summary_skips_already_summarized(client, db_conn, monkeypatch, app):
+    from app import decode
+    from app.routes import cron
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
+    calls = []
+    monkeypatch.setattr(cron, "summarize_and_tag", lambda crash_id, project_name: calls.append(crash_id))
+    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+
+    device_id = helpers.create_device(db_conn, "dev-cron-ai-2")
+    helpers.create_project(db_conn, "proj-cron-ai-done", github_user="esp-crash-bot")
+    helpers.create_elf_file(db_conn, "proj-cron-ai-done", "1.0")
+    helpers.create_crash(
+        db_conn, "proj-cron-ai-done", "1.0", device_id,
+        dump="already symbolicated", ai_summary="already summarized",
+    )
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+    assert calls == []
+
+
+def test_cron_ai_summary_failure_is_logged_and_skipped(client, db_conn, monkeypatch, app):
+    from app import decode
+    from app.routes import cron
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve)
+
+    def failing_summarize(crash_id, project_name):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cron, "summarize_and_tag", failing_summarize)
+    app.config["MCP_SERVICE_GITHUB_USER"] = "esp-crash-bot"
+
+    device_id = helpers.create_device(db_conn, "dev-cron-ai-3")
+    helpers.create_project(db_conn, "proj-cron-ai-fail", github_user="esp-crash-bot")
+    helpers.create_elf_file(db_conn, "proj-cron-ai-fail", "1.0")
+    crash_id = helpers.create_crash(db_conn, "proj-cron-ai-fail", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+    assert resp.data == b"OK\n"
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
+        assert cur.fetchone()[0] is None
+
+
 @pytest.mark.integration
 def test_cron_real_gdb_decode_path():
     """Requires the real xtensa ESP toolchain gdb (only present in the

--- a/esp-crash-server/tests/test_mcp_tools.py
+++ b/esp-crash-server/tests/test_mcp_tools.py
@@ -74,6 +74,7 @@ def test_get_crash_returns_dump_and_builds(app, db_conn, ctx):
     assert crash["ext_device_id"] == "dev-1"
     assert len(crash["builds"]) == 1
     assert crash["builds"][0]["project_alias"] == "build-x"
+    assert crash["ai_summary"] is None
     # dates serialized to ISO strings (JSON-friendly)
     assert isinstance(crash["date"], str)
 

--- a/esp-crash-server/tests/test_routes_crashes.py
+++ b/esp-crash-server/tests/test_routes_crashes.py
@@ -38,6 +38,27 @@ def test_refresh_crash_clears_dump_and_redirects(client, db_conn):
         assert cur.fetchone()[0] is None
 
 
+def test_show_project_crash_renders_ai_summary(client, db_conn):
+    helpers.create_project(db_conn, "proj-c6", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-c6")
+    crash_id = helpers.create_crash(
+        db_conn, "proj-c6", "1.0", device_id,
+        dump="dump text", ai_summary="This crash is a stack overflow.",
+    )
+    resp = client.get(f"/projects/proj-c6/{crash_id}")
+    assert resp.status_code == 200
+    assert b"This crash is a stack overflow." in resp.data
+
+
+def test_show_project_crash_omits_ai_summary_block_when_absent(client, db_conn):
+    helpers.create_project(db_conn, "proj-c7", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-c7")
+    crash_id = helpers.create_crash(db_conn, "proj-c7", "1.0", device_id, dump="dump text")
+    resp = client.get(f"/projects/proj-c7/{crash_id}")
+    assert resp.status_code == 200
+    assert b"bg-indigo-50" not in resp.data
+
+
 def test_delete_crash_removes_row_and_redirects(client, db_conn):
     helpers.create_project(db_conn, "proj-c5", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-c5")


### PR DESCRIPTION
## Summary
- Cron gets a second, independent pass: for crashes whose project has granted `MCP_SERVICE_GITHUB_USER` ACL access, call Claude (Sonnet 5) via the Anthropic Messages API's remote **MCP connector** (`mcp_servers` + `mcp_toolset`), pointed at this app's own MCP server. Claude autonomously calls `get_crash`/`list_tags`/`add_tag_to_crash` server-side inside one API call — no local MCP client code, no manual tool-use loop.
- New **service-token auth path** in `mcp_app/auth.py` (`MCP_SERVICE_TOKEN` / `MCP_SERVICE_GITHUB_USER`), additive alongside the existing browser-driven GitHub OAuth flow — a non-interactive caller authenticates with a static shared secret, but still resolves to a `project_auth`-gated identity like every other caller. A project only gets auto-tagged once its owner explicitly grants that identity access via the existing project settings ACL page.
- New nullable `Crash.ai_summary` column: doubles as the retry/idempotency gate for the new cron step and as the stored summary text, shown on the crash detail page and returned from the `get_crash`/`list_crashes` MCP tools.
- New required env vars for `backend`/`cron` (not committed — untracked `docker-compose.yml`): `ANTHROPIC_API_KEY`, `MCP_SERVICE_TOKEN` (must match the `mcp` service), `MCP_SERVICE_GITHUB_USER`, `MCP_PUBLIC_URL`.

## Test plan
- [x] `pytest` full suite green (117 passed, 1 skipped), including new tests: `summarize_and_tag` request shape + persistence (mocked Anthropic client, no real API calls), cron selection is scoped to ACL-granted projects and skips already-summarized crashes, an API failure leaves `ai_summary` NULL (retryable) without aborting the cron tick, crash-page rendering with/without a summary.
- [x] Alembic `upgrade head` verified directly against a scratch Postgres (confirmed `ai_summary text` column lands correctly); downgrade path is a plain `drop_column`, same shape already proven safe on the prior migration.
- [ ] After deploy: set the four new env vars on `backend`+`cron`, grant `MCP_SERVICE_GITHUB_USER` ACL access on a real project via the settings page, trigger a real crash, and confirm the next `/cron` tick populates `ai_summary` + tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)