### PR TITLE
Sort tag badges by name and display them uppercase on the crash list

### DIFF
--- a/esp-crash-server/app/routes/projects.py
+++ b/esp-crash-server/app/routes/projects.py
@@ -80,6 +80,7 @@ def list_project_crashes(project_name):
             select(CrashTag.crash_id, Tag.tag_id, Tag.name, Tag.description)
             .join(Tag, CrashTag.tag_id == Tag.tag_id)
             .where(CrashTag.crash_id.in_(crash_ids))
+            .order_by(Tag.name)
         ).mappings().all()
         for t in tag_rows:
             tags_by_crash.setdefault(t["crash_id"], []).append(

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -108,7 +108,7 @@ endblock %}
                     <div class="flex flex-wrap gap-1">
                         {% for t in crash.tags %}
                         <a href="{{ url_for(request.endpoint, project_name=project_name, tag_id=t.tag_id, search=search, limit=limit) }}"
-                           class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 hover:bg-amber-200"
+                           class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium uppercase bg-amber-100 text-amber-800 hover:bg-amber-200"
                            title="{{ t.description or '' }}">
                             {{ t.name }}
                         </a>

--- a/esp-crash-server/tests/test_routes_tags.py
+++ b/esp-crash-server/tests/test_routes_tags.py
@@ -65,3 +65,24 @@ def test_list_project_crashes_tag_filter(client, db_conn):
     resp = client.get(f"/projects/proj-t5?tag_id={tag_id}")
     assert resp.status_code == 200
     assert b"Filtered by tag" in resp.data
+
+
+def test_list_project_crashes_tags_sorted_uppercase(client, db_conn):
+    helpers.create_project(db_conn, "proj-t6", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t6")
+    crash_id = helpers.create_crash(db_conn, "proj-t6", "1.0", device_id)
+    # Inserted out of alphabetical order - the rendered badges must not be.
+    tag_z = helpers.create_tag(db_conn, "proj-t6", "zzztagz")
+    tag_a = helpers.create_tag(db_conn, "proj-t6", "aaataga")
+    tag_m = helpers.create_tag(db_conn, "proj-t6", "mmmtagm")
+    for tag_id in (tag_z, tag_a, tag_m):
+        helpers.tag_crash(db_conn, crash_id, tag_id)
+
+    resp = client.get("/projects/proj-t6")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    # Badges render lowercase tag names uppercased purely via CSS, so the
+    # underlying stored casing (and click-to-filter matching) is untouched -
+    # assert ordering on the stored names and the CSS class that uppercases them.
+    assert body.index("aaataga") < body.index("mmmtagm") < body.index("zzztagz")
+    assert 'class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium uppercase' in body


### PR DESCRIPTION
## Summary
- The crash list page's tag badges now sort by name (`ORDER BY Tag.name`), matching what the crash detail page already did.
- Tag badges display uppercase on the list page via CSS only (Tailwind `uppercase`) — the stored tag name stays lowercase, so click-to-filter and tag creation/matching are unaffected.

## Test plan
- [x] `pytest` full suite green (120 passed, 1 skipped), including a new test asserting badge order and the uppercase class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)