### PR TITLE
Crash page: uppercase tag badges, replace tag picker with a real dropdown

### DIFF
--- a/esp-crash-server/app/routes/tags.py
+++ b/esp-crash-server/app/routes/tags.py
@@ -22,7 +22,10 @@ def add_crash_tag(project_name, crash_id):
     if not allowed:
         return "Forbidden: You do not have access to this project.", 403
 
-    tag_name = (request.form.get('tag_name') or '').strip()
+    # A typed new-tag name takes priority over whatever's selected in the
+    # existing-tags dropdown, so picking a tag then also typing a new one
+    # does what it looks like it does.
+    tag_name = (request.form.get('new_tag_name') or request.form.get('tag_name') or '').strip()
     if not tag_name:
         return "Missing tag_name", 400
     tag_description = (request.form.get('tag_description') or '').strip() or None

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -81,7 +81,7 @@
 <div class="w-5/6 mt-4">
     <div class="flex flex-wrap items-center gap-2">
         {% for t in crash.tags %}
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800" title="{{ t.description or '' }}">
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium uppercase bg-amber-100 text-amber-800" title="{{ t.description or '' }}">
             <a href="{{ url_for('list_project_crashes', project_name=crash.project_name, tag_id=t.tag_id) }}" class="hover:underline">{{ t.name }}</a>
             <form method="post" action="{{ url_for('remove_crash_tag', project_name=crash.project_name, crash_id=crash.crash_id, tag_id=t.tag_id) }}" class="inline">
                 <button type="submit" class="ml-1 text-amber-800 hover:text-amber-900" title="Remove tag">&times;</button>
@@ -89,12 +89,14 @@
         </span>
         {% endfor %}
         <form method="post" action="{{ url_for('add_crash_tag', project_name=crash.project_name, crash_id=crash.crash_id) }}" class="flex items-center gap-1">
-            <input list="tag-options" name="tag_name" placeholder="Add a tag..." class="p-1 text-sm border-2 border-gray-300 rounded-md">
-            <datalist id="tag-options">
+            <select name="tag_name" class="p-1 text-sm uppercase border-2 border-gray-300 rounded-md">
+                <option value="">Select existing tag&hellip;</option>
                 {% for t in project_tags %}
-                <option value="{{ t.name }}">{{ t.description or '' }}</option>
+                <option value="{{ t.name }}" title="{{ t.description or '' }}">{{ t.name }}</option>
                 {% endfor %}
-            </datalist>
+            </select>
+            <span class="text-xs text-gray-400">or</span>
+            <input type="text" name="new_tag_name" placeholder="New tag name" class="p-1 text-sm border-2 border-gray-300 rounded-md">
             <input type="text" name="tag_description" placeholder="Description (new tags only)" class="p-1 text-sm border-2 border-gray-300 rounded-md">
             <button type="submit" class="p-1 px-2 text-sm bg-blue-500 text-white rounded-md">Add</button>
         </form>

--- a/esp-crash-server/tests/test_routes_tags.py
+++ b/esp-crash-server/tests/test_routes_tags.py
@@ -27,6 +27,29 @@ def test_add_crash_tag_requires_name(client, db_conn):
     assert resp.status_code == 400
 
 
+def test_add_crash_tag_new_tag_name_takes_priority(client, db_conn):
+    """Picking an existing tag in the dropdown AND typing a new one submits
+    both form fields - the typed one must win, matching what it looks like
+    the form does."""
+    helpers.create_project(db_conn, "proj-t1b", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t1b")
+    crash_id = helpers.create_crash(db_conn, "proj-t1b", "1.0", device_id)
+    helpers.create_tag(db_conn, "proj-t1b", "existing")
+
+    resp = client.post(
+        f"/projects/proj-t1b/{crash_id}/tags",
+        data={"tag_name": "existing", "new_tag_name": "Brand New"},
+    )
+    assert resp.status_code == 302
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT t.name FROM tag t JOIN crash_tag ct ON ct.tag_id = t.tag_id WHERE ct.crash_id = %s",
+            (crash_id,),
+        )
+        assert cur.fetchone()[0] == "brand new"
+
+
 def test_remove_crash_tag(client, db_conn):
     helpers.create_project(db_conn, "proj-t3", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-t3")
@@ -52,6 +75,28 @@ def test_crash_page_shows_tag_badge(client, db_conn):
     resp = client.get(f"/projects/proj-t4/{crash_id}")
     assert resp.status_code == 200
     assert b"duplicate" in resp.data
+    # Tag badges display uppercase (CSS only - stored name stays lowercase).
+    assert 'class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium uppercase' in resp.data.decode()
+
+
+def test_crash_page_tag_picker_is_a_visible_select(client, db_conn):
+    """The add-tag picker must be a real <select> listing the project's
+    existing tags, not an <input list>/<datalist> pair that renders as an
+    apparently-empty text box until you start typing."""
+    helpers.create_project(db_conn, "proj-t4b", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t4b")
+    crash_id = helpers.create_crash(db_conn, "proj-t4b", "1.0", device_id)
+    # A tag that exists for the project but isn't attached to this crash yet -
+    # exactly what the picker needs to show.
+    helpers.create_tag(db_conn, "proj-t4b", "unattached-tag", description="pick me")
+
+    resp = client.get(f"/projects/proj-t4b/{crash_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert '<select name="tag_name"' in body
+    assert '<option value="unattached-tag"' in body
+    assert "<datalist" not in body
+    assert 'name="new_tag_name"' in body
 
 
 def test_list_project_crashes_tag_filter(client, db_conn):


### PR DESCRIPTION
## Summary
- Tag badges on the crash detail page now display uppercase, matching the list page fix in #20 (CSS only via Tailwind `uppercase` - stored tag name stays lowercase for matching/creation).
- Diagnosed the "empty tag select box": it wasn't a data bug — the `<datalist>` was correctly populated server-side (verified directly), but `<input list>` + `<datalist>` renders as a plain, apparently-empty text box until you start typing, which reasonably reads as broken. Replaced it with a real `<select>` showing the project's existing tags, plus a separate "new tag name" field for creating one. If both are filled in, the typed new-tag name wins (matches what the form looks like it should do).

## Test plan
- [x] `pytest` full suite green (121 passed, 1 skipped), including new tests: the picker renders a real `<select>` with the project's existing tags and no `<datalist>`, and `new_tag_name` takes priority over a selected `tag_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)