### PR TITLE
Switch AI crash summarize/tag to Haiku 4.5 for cost

### DIFF
--- a/esp-crash-server/app/ai_tagging.py
+++ b/esp-crash-server/app/ai_tagging.py
@@ -14,7 +14,12 @@ from sqlalchemy import update
 from .models import Crash, db
 
 MCP_BETA = "mcp-client-2025-11-20"
-MODEL = "claude-sonnet-5"
+# Haiku 4.5 over Sonnet 5: this runs on every new crash, and in practice
+# most crashes within a project cluster around a handful of recurring root
+# causes (e.g. a firmware rollout tripping the same watchdog across many
+# devices at once) - reusing an existing tag is the common case, which
+# Haiku handles fine. Revisit if summary/tagging quality regresses.
+MODEL = "claude-haiku-4-5"
 
 
 def summarize_and_tag(crash_id, project_name):

--- a/esp-crash-server/tests/test_ai_tagging.py
+++ b/esp-crash-server/tests/test_ai_tagging.py
@@ -60,7 +60,7 @@ def test_summarize_and_tag_writes_summary_and_calls_mcp_connector(app, db_conn, 
     assert result == summary_text
     assert len(calls) == 1
     kwargs = calls[0]
-    assert kwargs["model"] == "claude-sonnet-5"
+    assert kwargs["model"] == "claude-haiku-4-5"
     assert kwargs["betas"] == ["mcp-client-2025-11-20"]
     assert kwargs["mcp_servers"][0]["url"] == "https://mcp-esp-crash.example/mcp"
     assert kwargs["mcp_servers"][0]["authorization_token"] == "svc-token"


### PR DESCRIPTION
## Summary
First of two cost levers discussed after a real incident (an OTA rollout tripped the same watchdog across ~6 devices in a couple minutes, each triggering a full Sonnet 5 + MCP tool-use call). Model swap is the quick lever; crash-signature deduplication (reuse tags from a recently-analyzed near-identical crash instead of calling the LLM again) is the higher-leverage follow-up, not included here.

- `app/ai_tagging.py`: `claude-sonnet-5` → `claude-haiku-4-5`. No config/schema changes.

## Test plan
- [x] `pytest` full suite green (123 passed, 1 skipped).
- [ ] After deploy: watch a few real crashes to confirm summary/tag quality is still acceptable at the cheaper model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)