### PR TITLE
Skip the Claude call for exact-content duplicate crashes

### DIFF
--- a/esp-crash-server/app/ai_tagging.py
+++ b/esp-crash-server/app/ai_tagging.py
@@ -9,9 +9,10 @@ matching how app.decode is split out for cron's symbolication step.
 """
 from anthropic import Anthropic
 from flask import current_app
-from sqlalchemy import update
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from .models import Crash, db
+from .models import Crash, CrashTag, db
 
 MCP_BETA = "mcp-client-2025-11-20"
 # Haiku 4.5 over Sonnet 5: this runs on every new crash, and in practice
@@ -22,11 +23,63 @@ MCP_BETA = "mcp-client-2025-11-20"
 MODEL = "claude-haiku-4-5"
 
 
+def _find_duplicate(project_name, dump, crash_id):
+    """Most recent other already-summarized crash in the same project whose
+    symbolicated output is byte-identical to this one's, if any. Matches on
+    Crash.dump (what the AI actually reads and what's shown on the crash
+    page) rather than the raw crash_dmp blob - it's the field that
+    determines the summary/tags, and it's deterministic for a true repeat
+    (e.g. a retried upload, or a device re-crashing in identical state).
+    Does NOT catch "same root cause, different device" - device-specific
+    state makes the symbolicated dump unique even for the same bug; that
+    needs fuzzy/signature matching, a separate follow-up."""
+    return db.session.execute(
+        select(Crash.crash_id, Crash.ai_summary)
+        .where(
+            Crash.project_name == project_name,
+            Crash.dump == dump,
+            Crash.ai_summary.is_not(None),
+            Crash.crash_id != crash_id,
+        )
+        .order_by(Crash.date.desc())
+        .limit(1)
+    ).mappings().first()
+
+
+def _copy_tags(source_crash_id, target_crash_id):
+    tag_ids = db.session.execute(
+        select(CrashTag.tag_id).where(CrashTag.crash_id == source_crash_id)
+    ).scalars().all()
+    for tag_id in tag_ids:
+        db.session.execute(
+            pg_insert(CrashTag).values(crash_id=target_crash_id, tag_id=tag_id)
+            .on_conflict_do_nothing(index_elements=["crash_id", "tag_id"])
+        )
+
+
 def summarize_and_tag(crash_id, project_name):
     """Ask Claude to summarize this crash and apply appropriate tags via the
     app's own MCP server, then store the summary. Raises on any failure -
     callers should catch, log, and move on: ai_summary stays NULL, so the
-    crash is picked up again on a later cron tick."""
+    crash is picked up again on a later cron tick.
+
+    First checks for an exact-content duplicate (see _find_duplicate) and,
+    if found, copies its summary and tags directly - no API call at all."""
+    dump = db.session.execute(
+        select(Crash.dump).where(Crash.crash_id == crash_id)
+    ).scalar_one_or_none()
+
+    if dump:
+        duplicate = _find_duplicate(project_name, dump, crash_id)
+        if duplicate is not None:
+            summary = f"(Same as crash #{duplicate['crash_id']}.) {duplicate['ai_summary']}"
+            _copy_tags(duplicate["crash_id"], crash_id)
+            db.session.execute(
+                update(Crash).where(Crash.crash_id == crash_id).values(ai_summary=summary)
+            )
+            db.session.commit()
+            return summary
+
     client = Anthropic(api_key=current_app.config["ANTHROPIC_API_KEY"])
     mcp_url = current_app.config["MCP_PUBLIC_URL"].rstrip("/") + "/mcp"
 

--- a/esp-crash-server/tests/test_ai_tagging.py
+++ b/esp-crash-server/tests/test_ai_tagging.py
@@ -70,3 +70,80 @@ def test_summarize_and_tag_writes_summary_and_calls_mcp_connector(app, db_conn, 
     with db_conn.cursor() as cur:
         cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
         assert cur.fetchone()[0] == summary_text
+
+
+def test_summarize_and_tag_reuses_exact_duplicate_without_calling_api(app, db_conn, monkeypatch):
+    calls = []
+
+    def fail_if_called(api_key=None):
+        raise AssertionError("Anthropic client should not be constructed for an exact-content duplicate")
+
+    monkeypatch.setattr(ai_tagging, "Anthropic", fail_if_called)
+
+    helpers.create_project(db_conn, "proj-ai-dup", github_user="alice")
+    device_id = helpers.create_device(db_conn, "dev-ai-dup")
+    same_dump = "identical symbolicated backtrace"
+
+    source_id = helpers.create_crash(
+        db_conn, "proj-ai-dup", "1.0", device_id,
+        dump=same_dump, ai_summary="Watchdog fired in ota_manifest task.",
+    )
+    tag_id = helpers.create_tag(db_conn, "proj-ai-dup", "watchdog")
+    helpers.tag_crash(db_conn, source_id, tag_id)
+
+    new_id = helpers.create_crash(db_conn, "proj-ai-dup", "1.0", device_id, dump=same_dump)
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(new_id, "proj-ai-dup")
+
+    assert calls == []
+    assert str(source_id) in result
+    assert "Watchdog fired in ota_manifest task." in result
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (new_id,))
+        assert "Watchdog fired in ota_manifest task." in cur.fetchone()[0]
+        cur.execute(
+            "SELECT t.name FROM tag t JOIN crash_tag ct ON ct.tag_id = t.tag_id WHERE ct.crash_id = %s",
+            (new_id,),
+        )
+        assert cur.fetchone()[0] == "watchdog"
+
+
+def test_summarize_and_tag_ignores_duplicates_from_other_projects(app, db_conn, monkeypatch):
+    """Same dump text in a different project must not be treated as a
+    duplicate - tags are project-scoped and coincidental content matches
+    across unrelated projects shouldn't short-circuit real analysis."""
+    calls = []
+    summary_text = "Fresh analysis, no duplicate found."
+    fake_response = _FakeResponse(summary_text)
+    monkeypatch.setattr(
+        ai_tagging, "Anthropic",
+        lambda api_key=None: _FakeAnthropicClient(fake_response, calls),
+    )
+
+    same_dump = "identical text, different project"
+    helpers.create_project(db_conn, "proj-ai-other-a", github_user="alice")
+    device_a = helpers.create_device(db_conn, "dev-ai-other-a")
+    helpers.create_crash(
+        db_conn, "proj-ai-other-a", "1.0", device_a,
+        dump=same_dump, ai_summary="Summary from a different project.",
+    )
+
+    helpers.create_project(db_conn, "proj-ai-other-b", github_user="alice")
+    device_b = helpers.create_device(db_conn, "dev-ai-other-b")
+    new_id = helpers.create_crash(db_conn, "proj-ai-other-b", "1.0", device_b, dump=same_dump)
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(new_id, "proj-ai-other-b")
+
+    assert len(calls) == 1
+    assert result == summary_text


### PR DESCRIPTION
## Summary
Second cost lever from the incident discussion (first was #22, the Haiku 4.5 model swap).

- Before calling the API, `summarize_and_tag` now checks for another already-summarized crash in the same project with a byte-identical symbolicated `dump`. If found, it copies that crash's summary (prefixed with `(Same as crash #N.)`) and tags directly - zero API cost.
- **Scope note:** this catches true repeats (a retried upload, a device re-crashing in identical state) but **not** "same root cause, different device" - I checked the recent `ota_manifest` watchdog incident, and the symbolicated dumps differed across all 6 affected devices (device-specific stack/register state), so exact matching wouldn't have caught that one. Catching that pattern needs fuzzy/signature-based matching on top of this - a separate follow-up if wanted.

## Test plan
- [x] `pytest` full suite green (125 passed, 1 skipped): duplicate crash reuses summary+tags with zero API calls (mock raises if the Anthropic client is even constructed); a coincidental same-text match in a *different* project is correctly ignored and still gets a real API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)