### PR TITLE
Persist MCP OAuth client/token store to the DB

### DIFF
--- a/esp-crash-server/alembic/versions/48bdaa31d2f9_persist_mcp_oauth_store.py
+++ b/esp-crash-server/alembic/versions/48bdaa31d2f9_persist_mcp_oauth_store.py
@@ -1,0 +1,58 @@
+"""persist mcp oauth store
+
+Revision ID: 48bdaa31d2f9
+Revises: 6beade548d43
+Create Date: 2026-08-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '48bdaa31d2f9'
+down_revision: Union[str, Sequence[str], None] = '6beade548d43'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'mcp_oauth_client',
+        sa.Column('client_id', sa.Text(), nullable=False),
+        sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=True),
+        sa.PrimaryKeyConstraint('client_id'),
+    )
+    op.create_table(
+        'mcp_access_token',
+        sa.Column('token', sa.Text(), nullable=False),
+        sa.Column('client_id', sa.Text(), nullable=False),
+        sa.Column('expires_at', sa.BigInteger(), nullable=True),
+        sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=True),
+        sa.PrimaryKeyConstraint('token'),
+    )
+    op.create_index(
+        'idx_mcp_access_token_expires_at', 'mcp_access_token', ['expires_at'], unique=False
+    )
+    op.create_table(
+        'mcp_refresh_token',
+        sa.Column('token', sa.Text(), nullable=False),
+        sa.Column('client_id', sa.Text(), nullable=False),
+        sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=True),
+        sa.PrimaryKeyConstraint('token'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('mcp_refresh_token')
+    op.drop_index('idx_mcp_access_token_expires_at', table_name='mcp_access_token')
+    op.drop_table('mcp_access_token')
+    op.drop_table('mcp_oauth_client')

--- a/esp-crash-server/app/models.py
+++ b/esp-crash-server/app/models.py
@@ -134,6 +134,44 @@ class CrashTag(db.Model):
     )
 
 
+class McpOAuthClient(db.Model):
+    """Dynamically-registered MCP OAuth clients (RFC 7591). `data` is the
+    full serialized mcp.shared.auth.OAuthClientInformationFull - stored as a
+    blob rather than column-per-field so the store tracks the SDK's model
+    without a migration every time it gains a field."""
+    __tablename__ = "mcp_oauth_client"
+
+    client_id = db.Column(db.Text, primary_key=True)
+    data = db.Column(JSONB, nullable=False)
+    created_at = db.Column(db.TIMESTAMP, server_default=db.func.now())
+
+
+class McpAccessToken(db.Model):
+    """Issued MCP bearer access tokens. expires_at is duplicated out of
+    `data` (a serialized mcp.server.auth.provider.AccessToken) as a plain
+    column purely so expiry can be checked/cleaned up in SQL."""
+    __tablename__ = "mcp_access_token"
+    __table_args__ = (
+        db.Index("idx_mcp_access_token_expires_at", "expires_at"),
+    )
+
+    token = db.Column(db.Text, primary_key=True)
+    client_id = db.Column(db.Text, nullable=False)
+    expires_at = db.Column(db.BigInteger)
+    data = db.Column(JSONB, nullable=False)
+    created_at = db.Column(db.TIMESTAMP, server_default=db.func.now())
+
+
+class McpRefreshToken(db.Model):
+    """Issued MCP refresh tokens (serialized mcp.server.auth.provider.RefreshToken)."""
+    __tablename__ = "mcp_refresh_token"
+
+    token = db.Column(db.Text, primary_key=True)
+    client_id = db.Column(db.Text, nullable=False)
+    data = db.Column(JSONB, nullable=False)
+    created_at = db.Column(db.TIMESTAMP, server_default=db.func.now())
+
+
 class ModuleElf(db.Model):
     __tablename__ = "module_elf"
     __table_args__ = (

--- a/esp-crash-server/mcp_app/auth.py
+++ b/esp-crash-server/mcp_app/auth.py
@@ -9,15 +9,23 @@ which the tools read to enforce per-user ACLs.
 
 The SDK's token handler verifies PKCE (S256) and redirect_uri consistency
 before calling exchange_authorization_code, so this provider does not repeat
-that. Client/code/token stores are in-memory: fine for v1, but tokens reset on
-process restart (clients must re-authenticate) - persisting them (e.g. a DB
-table) is a deliberate follow-up.
+that. Registered clients and issued access/refresh tokens are persisted to
+the DB (mcp_oauth_client / mcp_access_token / mcp_refresh_token, each a
+client_id-or-token-keyed row plus a JSONB dump of the SDK's Pydantic model)
+so an `mcp` container restart - routine during active development - doesn't
+force every already-registered client to re-authenticate. Authorization
+codes and the upstream-GitHub-flow `_pending` state are deliberately left
+in-memory: both are short-lived (a single live browser round-trip / a
+600s-TTL code), so losing them on restart just means a login in flight has
+to be retried, not a full re-auth.
 """
 import secrets
 import time
 from urllib.parse import urlencode
 
 import httpx
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
 
@@ -31,6 +39,8 @@ from mcp.server.auth.provider import (
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
+from app.models import McpAccessToken, McpOAuthClient, McpRefreshToken, db
+
 GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_USER_URL = "https://api.github.com/user"
@@ -43,9 +53,15 @@ class GitHubOAuthProvider(
     OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]
 ):
     def __init__(
-        self, github_client_id, github_client_secret, callback_url, mcp_scope="esp-crash",
-        service_token=None, service_github_user=None,
+        self, flask_app, github_client_id, github_client_secret, callback_url,
+        mcp_scope="esp-crash", service_token=None, service_github_user=None,
     ):
+        # Methods here run outside any Flask request cycle (invoked directly
+        # by FastMCP/Starlette internals), so DB-touching code below pushes
+        # its own app context via this handle rather than relying on one
+        # already being active - same reasoning as the @mcp.tool wrappers in
+        # server.py.
+        self.flask_app = flask_app
         self.github_client_id = github_client_id
         self.github_client_secret = github_client_secret
         self.callback_url = callback_url  # {MCP_PUBLIC_URL}/github/callback
@@ -59,20 +75,30 @@ class GitHubOAuthProvider(
         self.service_token = service_token
         self.service_github_user = service_github_user
 
-        self.clients: dict[str, OAuthClientInformationFull] = {}
         self.auth_codes: dict[str, AuthorizationCode] = {}
-        self.access_tokens: dict[str, AccessToken] = {}
-        self.refresh_tokens: dict[str, RefreshToken] = {}
         # upstream-flow state -> (mcp_client_id, original AuthorizationParams)
         self._pending: dict[str, tuple[str, AuthorizationParams]] = {}
 
     # ---- dynamic client registration --------------------------------------
 
     async def get_client(self, client_id):
-        return self.clients.get(client_id)
+        with self.flask_app.app_context():
+            row = db.session.get(McpOAuthClient, client_id)
+            if row is None:
+                return None
+            return OAuthClientInformationFull.model_validate(row.data)
 
     async def register_client(self, client_info):
-        self.clients[client_info.client_id] = client_info
+        with self.flask_app.app_context():
+            db.session.execute(
+                pg_insert(McpOAuthClient)
+                .values(client_id=client_info.client_id, data=client_info.model_dump(mode="json"))
+                .on_conflict_do_update(
+                    index_elements=["client_id"],
+                    set_={"data": client_info.model_dump(mode="json")},
+                )
+            )
+            db.session.commit()
 
     # ---- authorize: delegate to GitHub ------------------------------------
 
@@ -156,13 +182,19 @@ class GitHubOAuthProvider(
     # ---- refresh -----------------------------------------------------------
 
     async def load_refresh_token(self, client, refresh_token):
-        rt = self.refresh_tokens.get(refresh_token)
-        if rt is None or rt.client_id != client.client_id:
+        with self.flask_app.app_context():
+            row = db.session.get(McpRefreshToken, refresh_token)
+            if row is None:
+                return None
+            rt = RefreshToken.model_validate(row.data)
+        if rt.client_id != client.client_id:
             return None
         return rt
 
     async def exchange_refresh_token(self, client, refresh_token, scopes):
-        self.refresh_tokens.pop(refresh_token.token, None)
+        with self.flask_app.app_context():
+            db.session.execute(delete(McpRefreshToken).where(McpRefreshToken.token == refresh_token.token))
+            db.session.commit()
         return self._issue_tokens(
             client.client_id, scopes or refresh_token.scopes, refresh_token.subject
         )
@@ -175,18 +207,23 @@ class GitHubOAuthProvider(
                 token=token, client_id="service", scopes=[self.mcp_scope],
                 expires_at=None, subject=self.service_github_user,
             )
-        at = self.access_tokens.get(token)
-        if at is None:
-            return None
-        if at.expires_at is not None and at.expires_at < time.time():
-            self.access_tokens.pop(token, None)
-            return None
-        return at
+        with self.flask_app.app_context():
+            row = db.session.get(McpAccessToken, token)
+            if row is None:
+                return None
+            at = AccessToken.model_validate(row.data)
+            if at.expires_at is not None and at.expires_at < time.time():
+                db.session.delete(row)
+                db.session.commit()
+                return None
+            return at
 
     async def revoke_token(self, token):
         # token is an AccessToken or RefreshToken; drop from whichever store.
-        self.access_tokens.pop(token.token, None)
-        self.refresh_tokens.pop(token.token, None)
+        with self.flask_app.app_context():
+            db.session.execute(delete(McpAccessToken).where(McpAccessToken.token == token.token))
+            db.session.execute(delete(McpRefreshToken).where(McpRefreshToken.token == token.token))
+            db.session.commit()
 
     # ---- helpers -----------------------------------------------------------
 
@@ -194,13 +231,28 @@ class GitHubOAuthProvider(
         access = secrets.token_urlsafe(32)
         refresh = secrets.token_urlsafe(32)
         now = int(time.time())
-        self.access_tokens[access] = AccessToken(
+        access_token = AccessToken(
             token=access, client_id=client_id, scopes=scopes,
             expires_at=now + _ACCESS_TOKEN_TTL, subject=subject,
         )
-        self.refresh_tokens[refresh] = RefreshToken(
+        refresh_token = RefreshToken(
             token=refresh, client_id=client_id, scopes=scopes, subject=subject,
         )
+        with self.flask_app.app_context():
+            db.session.execute(
+                pg_insert(McpAccessToken).values(
+                    token=access, client_id=client_id,
+                    expires_at=access_token.expires_at,
+                    data=access_token.model_dump(mode="json"),
+                )
+            )
+            db.session.execute(
+                pg_insert(McpRefreshToken).values(
+                    token=refresh, client_id=client_id,
+                    data=refresh_token.model_dump(mode="json"),
+                )
+            )
+            db.session.commit()
         return OAuthToken(
             access_token=access, token_type="Bearer", expires_in=_ACCESS_TOKEN_TTL,
             scope=" ".join(scopes), refresh_token=refresh,

--- a/esp-crash-server/mcp_app/server.py
+++ b/esp-crash-server/mcp_app/server.py
@@ -56,6 +56,7 @@ def build_app():
     flask_app = _make_db_app()
 
     provider = GitHubOAuthProvider(
+        flask_app=flask_app,
         github_client_id=github_client_id,
         github_client_secret=github_client_secret,
         callback_url=f"{public_url}/github/callback",

--- a/esp-crash-server/tests/conftest.py
+++ b/esp-crash-server/tests/conftest.py
@@ -111,6 +111,9 @@ TABLES_TO_TRUNCATE = (
     "project_slack_integrations",
     "project_settings",
     "module_elf",
+    "mcp_oauth_client",
+    "mcp_access_token",
+    "mcp_refresh_token",
 )
 
 

--- a/esp-crash-server/tests/test_mcp_auth.py
+++ b/esp-crash-server/tests/test_mcp_auth.py
@@ -1,0 +1,138 @@
+"""Tests for mcp_app/auth.py's DB-backed OAuth client/token storage.
+
+Each test constructs GitHubOAuthProvider directly (no HTTP transport) against
+the `app` fixture's Flask app, which already owns a SQLAlchemy session for
+the throwaway test DB - exactly the object mcp_app/server.py passes in as
+flask_app. Provider methods are async (the SDK's protocol requires it), so
+they're driven with asyncio.run() rather than pytest-asyncio (not a project
+dependency).
+"""
+import asyncio
+import time
+
+from mcp.server.auth.provider import AccessToken, RefreshToken
+from mcp.shared.auth import OAuthClientInformationFull
+
+from mcp_app.auth import GitHubOAuthProvider
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _provider(app):
+    return GitHubOAuthProvider(
+        flask_app=app,
+        github_client_id="gh-client-id",
+        github_client_secret="gh-client-secret",
+        callback_url="https://mcp.example/github/callback",
+    )
+
+
+def test_register_client_persists_across_provider_instances(app, db_conn):
+    client_info = OAuthClientInformationFull(
+        client_id="client-abc",
+        client_secret="secret-abc",
+        redirect_uris=["http://localhost:12345/callback"],
+    )
+    _run(_provider(app).register_client(client_info))
+
+    # A fresh instance stands in for a restarted `mcp` container/process -
+    # the whole point is that this must NOT be an empty in-memory dict.
+    loaded = _run(_provider(app).get_client("client-abc"))
+    assert loaded is not None
+    assert loaded.client_id == "client-abc"
+    assert loaded.client_secret == "secret-abc"
+    assert str(loaded.redirect_uris[0]) == "http://localhost:12345/callback"
+
+
+def test_get_client_missing_returns_none(app, db_conn):
+    assert _run(_provider(app).get_client("nope")) is None
+
+
+def test_issued_access_token_persists_and_loads(app, db_conn):
+    provider = _provider(app)
+    token = provider._issue_tokens(client_id="client-1", scopes=["esp-crash"], subject="alice")
+
+    # Simulate a restart: new provider instance, same DB.
+    loaded = _run(_provider(app).load_access_token(token.access_token))
+    assert loaded is not None
+    assert loaded.client_id == "client-1"
+    assert loaded.subject == "alice"
+    assert loaded.scopes == ["esp-crash"]
+
+
+def test_load_access_token_expired_is_purged(app, db_conn):
+    provider = _provider(app)
+    with app.app_context():
+        from app.models import McpAccessToken, db as sa_db
+
+        sa_db.session.add(McpAccessToken(
+            token="expired-tok", client_id="client-1", expires_at=int(time.time()) - 10,
+            data=AccessToken(
+                token="expired-tok", client_id="client-1", scopes=["esp-crash"],
+                expires_at=int(time.time()) - 10, subject="alice",
+            ).model_dump(mode="json"),
+        ))
+        sa_db.session.commit()
+
+    assert _run(provider.load_access_token("expired-tok")) is None
+
+    with app.app_context():
+        from app.models import McpAccessToken, db as sa_db
+
+        assert sa_db.session.get(McpAccessToken, "expired-tok") is None
+
+
+def test_load_access_token_service_token_short_circuits_without_db(app, db_conn):
+    provider = GitHubOAuthProvider(
+        flask_app=app,
+        github_client_id="gh-client-id",
+        github_client_secret="gh-client-secret",
+        callback_url="https://mcp.example/github/callback",
+        service_token="svc-secret",
+        service_github_user="esp-crash-bot",
+    )
+    loaded = _run(provider.load_access_token("svc-secret"))
+    assert loaded is not None
+    assert loaded.client_id == "service"
+    assert loaded.subject == "esp-crash-bot"
+
+
+def test_refresh_token_exchange_rotates_and_persists(app, db_conn):
+    provider = _provider(app)
+    issued = provider._issue_tokens(client_id="client-1", scopes=["esp-crash"], subject="alice")
+
+    class _Client:
+        client_id = "client-1"
+
+    old_refresh = _run(provider.load_refresh_token(_Client(), issued.refresh_token))
+    assert old_refresh is not None
+
+    new_tokens = _run(provider.exchange_refresh_token(_Client(), old_refresh, ["esp-crash"]))
+    assert new_tokens.access_token != issued.access_token
+    assert new_tokens.refresh_token != issued.refresh_token
+
+    # Old refresh token is gone (single use); a fresh provider instance
+    # confirms this isn't just an in-memory pop.
+    assert _run(_provider(app).load_refresh_token(_Client(), issued.refresh_token)) is None
+    # The new access token is loadable, including after a simulated restart.
+    assert _run(_provider(app).load_access_token(new_tokens.access_token)) is not None
+
+
+def test_revoke_token_removes_access_and_refresh_rows(app, db_conn):
+    provider = _provider(app)
+    issued = provider._issue_tokens(client_id="client-1", scopes=["esp-crash"], subject="alice")
+
+    _run(provider.revoke_token(AccessToken(
+        token=issued.access_token, client_id="client-1", scopes=["esp-crash"], subject="alice",
+    )))
+    assert _run(_provider(app).load_access_token(issued.access_token)) is None
+
+    class _Client:
+        client_id = "client-1"
+
+    _run(provider.revoke_token(RefreshToken(
+        token=issued.refresh_token, client_id="client-1", scopes=["esp-crash"], subject="alice",
+    )))
+    assert _run(_provider(app).load_refresh_token(_Client(), issued.refresh_token)) is None


### PR DESCRIPTION
## Summary
- `GitHubOAuthProvider`'s registered-client/access-token/refresh-token stores move from in-memory dicts to three new DB tables (`mcp_oauth_client`, `mcp_access_token`, `mcp_refresh_token`), each keyed by client_id/token with a JSONB dump of the SDK's Pydantic model.
- Fixes the recurring "Client ID not found" error: every `mcp` container restart previously wiped all registered OAuth clients and issued tokens, forcing every already-connected Claude client to re-authenticate.
- Authorization codes and the upstream-GitHub-flow `_pending` state are deliberately left in-memory - both are short-lived (a single live browser round-trip / a 600s-TTL code), so losing them on restart just means retrying a login in flight, not a full re-auth.
- New Alembic migration `48bdaa31d2f9` chained from `6beade548d43`.

## Test plan
- [x] Full `pytest` suite green (157 passed, 1 skipped) including new `tests/test_mcp_auth.py` covering: client registration surviving a simulated restart, access token issue/load/expiry-purge, the service-token short-circuit still bypassing the DB, refresh-token rotation, and revocation.
- [ ] After merge: deploy, then confirm an existing MCP client connection survives an `mcp` container restart without needing to re-login.