### PR TITLE
Non-AI crash duplicate signature + Related crashes link

### DIFF
--- a/esp-crash-server/alembic/versions/7a1c9e2f5b3d_add_crash_signature.py
+++ b/esp-crash-server/alembic/versions/7a1c9e2f5b3d_add_crash_signature.py
@@ -1,0 +1,30 @@
+"""add crash signature
+
+Revision ID: 7a1c9e2f5b3d
+Revises: 48bdaa31d2f9
+Create Date: 2026-08-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7a1c9e2f5b3d'
+down_revision: Union[str, Sequence[str], None] = '48bdaa31d2f9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('crash', sa.Column('signature', sa.Text(), nullable=True))
+    op.create_index('idx_crash_signature', 'crash', ['signature'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_crash_signature', table_name='crash')
+    op.drop_column('crash', 'signature')

--- a/esp-crash-server/app/ai_tagging.py
+++ b/esp-crash-server/app/ai_tagging.py
@@ -31,13 +31,32 @@ def _find_duplicate(project_name, dump, crash_id):
     determines the summary/tags, and it's deterministic for a true repeat
     (e.g. a retried upload, or a device re-crashing in identical state).
     Does NOT catch "same root cause, different device" - device-specific
-    state makes the symbolicated dump unique even for the same bug; that
-    needs fuzzy/signature matching, a separate follow-up."""
+    state makes the symbolicated dump unique even for the same bug; see
+    _find_signature_duplicate for that case."""
     return db.session.execute(
         select(Crash.crash_id, Crash.ai_summary)
         .where(
             Crash.project_name == project_name,
             Crash.dump == dump,
+            Crash.ai_summary.is_not(None),
+            Crash.crash_id != crash_id,
+        )
+        .order_by(Crash.date.desc())
+        .limit(1)
+    ).mappings().first()
+
+
+def _find_signature_duplicate(project_name, signature, crash_id):
+    """Most recent other already-summarized crash in the same project with
+    the same non-AI crash_signature.py fingerprint - catches "same root
+    cause, different device" duplicates that _find_duplicate's exact-dump
+    match misses (e.g. a watchdog firing on the same task across many
+    devices, where only pointer/register values differ)."""
+    return db.session.execute(
+        select(Crash.crash_id, Crash.ai_summary)
+        .where(
+            Crash.project_name == project_name,
+            Crash.signature == signature,
             Crash.ai_summary.is_not(None),
             Crash.crash_id != crash_id,
         )
@@ -63,14 +82,18 @@ def summarize_and_tag(crash_id, project_name):
     callers should catch, log, and move on: ai_summary stays NULL, so the
     crash is picked up again on a later cron tick.
 
-    First checks for an exact-content duplicate (see _find_duplicate) and,
-    if found, copies its summary and tags directly - no API call at all."""
-    dump = db.session.execute(
-        select(Crash.dump).where(Crash.crash_id == crash_id)
-    ).scalar_one_or_none()
+    First checks for an exact-content duplicate (see _find_duplicate), then
+    a same-signature duplicate (see _find_signature_duplicate) and, if
+    either is found, copies its summary and tags directly - no API call at
+    all."""
+    dump, signature = db.session.execute(
+        select(Crash.dump, Crash.signature).where(Crash.crash_id == crash_id)
+    ).one_or_none() or (None, None)
 
     if dump:
         duplicate = _find_duplicate(project_name, dump, crash_id)
+        if duplicate is None and signature:
+            duplicate = _find_signature_duplicate(project_name, signature, crash_id)
         if duplicate is not None:
             summary = f"(Same as crash #{duplicate['crash_id']}.) {duplicate['ai_summary']}"
             _copy_tags(duplicate["crash_id"], crash_id)

--- a/esp-crash-server/app/crash_signature.py
+++ b/esp-crash-server/app/crash_signature.py
@@ -1,0 +1,49 @@
+"""Fingerprint a symbolicated crash dump for duplicate grouping, without
+calling an LLM. Addresses, register values, and call-argument values (all
+pointer/runtime state) differ between devices and even between two crashes
+from the *same* bug, so they can't be part of a duplicate signature. What's
+stable for "this is the same bug" is the ordered sequence of function names
+in the GDB backtrace's `CURRENT THREAD STACK` section - confirmed against
+real crash dumps in this project (e.g. the ota_manifest watchdog case: two
+different devices, identical function-name sequence, differing only in
+addresses/timer handles).
+
+The outermost few frames (panic_abort/esp_system_abort/abort/the FreeRTOS
+task wrapper) are dropped before hashing - they're present on every crash
+regardless of cause and would otherwise dominate a short signature.
+"""
+import hashlib
+import re
+
+_STACK_HEADER = "CURRENT THREAD STACK"
+_SECTION_RULE = re.compile(r'^=+ .+ =+$')
+_FRAME_RE = re.compile(r'^#\d+\s+(?:0x[0-9a-fA-F]+\s+in\s+)?([A-Za-z_]\w*)\s*\(')
+_GENERIC_FRAMES = {"panic_abort", "esp_system_abort", "abort", "vPortTaskWrapper"}
+_FRAME_COUNT = 6
+
+
+def _stack_frames(dump):
+    lines = dump.splitlines()
+    start = next((i for i, line in enumerate(lines) if _STACK_HEADER in line), None)
+    if start is None:
+        return []
+    frames = []
+    for line in lines[start + 1:]:
+        stripped = line.strip()
+        if _SECTION_RULE.match(stripped):
+            break
+        m = _FRAME_RE.match(stripped)
+        if m:
+            frames.append(m.group(1))
+    return frames
+
+
+def compute_signature(dump):
+    """Hex signature grouping crashes with the same root cause, or None if
+    `dump` has no parseable GDB backtrace (e.g. a decode failure message)."""
+    if not dump:
+        return None
+    frames = [f for f in _stack_frames(dump) if f not in _GENERIC_FRAMES][:_FRAME_COUNT]
+    if not frames:
+        return None
+    return hashlib.sha256("|".join(frames).encode()).hexdigest()

--- a/esp-crash-server/app/models.py
+++ b/esp-crash-server/app/models.py
@@ -24,6 +24,7 @@ class Crash(db.Model):
     __table_args__ = (
         db.Index("textsearch_idx", "textsearch", postgresql_using="gin"),
         db.Index("idx_crash_project_name_ver", "project_name", "project_ver"),
+        db.Index("idx_crash_signature", "signature"),
     )
 
     crash_id = db.Column(db.Integer, primary_key=True)
@@ -39,6 +40,10 @@ class Crash(db.Model):
     module_names = db.Column(ARRAY(db.Text))
     module_map = db.Column(JSONB)
     ai_summary = db.Column(db.Text)
+    # Non-AI duplicate-grouping fingerprint - see app/crash_signature.py.
+    # NULL for crashes not yet backfilled or whose dump has no parseable
+    # GDB backtrace.
+    signature = db.Column(db.Text)
 
 
 class ElfFile(db.Model):

--- a/esp-crash-server/app/routes/crashes.py
+++ b/esp-crash-server/app/routes/crashes.py
@@ -34,6 +34,7 @@ def show_project_crash(project_name, crash_id):
             Crash.project_ver, Crash.crash_dmp, Device.ext_device_id,
             func.coalesce(Device.alias, "").label("device_alias"), Crash.dump,
             ProjectSettings.device_url_template, Crash.module_map, Crash.ai_summary,
+            Crash.signature,
         )
         .select_from(Crash)
         .join(ProjectAuth, Crash.project_name == ProjectAuth.project_name)

--- a/esp-crash-server/app/routes/cron.py
+++ b/esp-crash-server/app/routes/cron.py
@@ -17,6 +17,7 @@ from sqlalchemy import func, select, update
 import decode_module_coredump as mod_decoder
 from .. import decode
 from ..ai_tagging import summarize_and_tag
+from ..crash_signature import compute_signature
 from ..models import Crash, ElfFile, ProjectAuth, ProjectSlackIntegration, ProjectWebhook, db
 from ..rendering import external_url_for
 
@@ -101,7 +102,10 @@ def cron():
         db.session.execute(
             update(Crash)
             .where(Crash.crash_id == crash["crash_id"])
-            .values(dump=dump, module_names=module_names, module_map=last_module_map)
+            .values(
+                dump=dump, module_names=module_names, module_map=last_module_map,
+                signature=compute_signature(dump),
+            )
         )
         db.session.commit()
         current_app.logger.info("Updated crash {} (modules: {})".format(crash["crash_id"], module_names))
@@ -260,6 +264,29 @@ def cron():
                     current_app.logger.error(f"Unexpected error sending Slack notification for crash {crash['crash_id']}: {e}")
         else:
             current_app.logger.info(f"No Slack integrations found for project {project_name}")
+
+    # Non-AI duplicate-signature backfill: crashes that already have a dump
+    # but predate this feature (or whose earlier signature attempt found no
+    # parseable backtrace, e.g. a decode-failure dump - those legitimately
+    # stay NULL and get harmlessly re-checked each tick). Pure local
+    # computation, no external calls - unlike the AI step below there's no
+    # cost or backlog-explosion concern, so a generous batch size just runs
+    # the backlog down over a handful of ticks.
+    backfill_targets = db.session.execute(
+        select(Crash.crash_id, Crash.dump)
+        .where(Crash.dump.is_not(None), Crash.signature.is_(None))
+        .order_by(Crash.crash_id.desc())
+        .limit(500)
+    ).mappings().all()
+    if backfill_targets:
+        processed_anything = True
+        for row in backfill_targets:
+            db.session.execute(
+                update(Crash).where(Crash.crash_id == row["crash_id"])
+                .values(signature=compute_signature(row["dump"]))
+            )
+        db.session.commit()
+        current_app.logger.info(f"Backfilled signature for {len(backfill_targets)} crashes")
 
     # AI summary + tagging: a second, independent pass with its own retry
     # gate (ai_summary IS NULL), scoped to projects that have explicitly

--- a/esp-crash-server/app/routes/projects.py
+++ b/esp-crash-server/app/routes/projects.py
@@ -25,6 +25,7 @@ def list_project_crashes(project_name):
     limit = int(request.args.get('limit', 50))
     tag_id = request.args.get('tag_id', None)
     tag_id = int(tag_id) if tag_id else None
+    signature = request.args.get('signature', None) or None
 
     conditions = [auth_filter(ProjectAuth.github)]
     if project_name:
@@ -33,6 +34,8 @@ def list_project_crashes(project_name):
         conditions.append(Crash.textsearch.op("@@")(func.plainto_tsquery(search)))
     if tag_id:
         conditions.append(Crash.crash_id.in_(select(CrashTag.crash_id).where(CrashTag.tag_id == tag_id)))
+    if signature:
+        conditions.append(Crash.signature == signature)
 
     crashes = db.session.execute(
         select(
@@ -96,7 +99,7 @@ def list_project_crashes(project_name):
 
     # crash.module_names is populated at cron processing time, so no per-row
     # coredump parsing happens here.
-    return render_template('project.html', crashes = crashes, project_name = project_name, search = search or "", limit = limit, offset = offset, tag_id = tag_id, active_tag = active_tag, full_count = crashes[0]["full_count"] if len(crashes) > 0 else 0)
+    return render_template('project.html', crashes = crashes, project_name = project_name, search = search or "", limit = limit, offset = offset, tag_id = tag_id, active_tag = active_tag, signature = signature, full_count = crashes[0]["full_count"] if len(crashes) > 0 else 0)
 
 
 @login_required

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -41,6 +41,16 @@
         <span>Project</span>
     </a>
     {% endif %}
+    {% if crash.signature %}
+    <a href="{{ url_for('list_crashes', signature=crash.signature) }}" class="flex items-center p-4 " title="Other crashes with the same stack signature (no AI involved)">
+        <svg class="w-6 h-6 stroke-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5m4.656-4.656l1.5-1.5a4 4 0 115.656 5.656l-3 3a4 4 0 01-5.656 0" />
+        </svg>
+        <span>Related</span>
+    </a>
+    {% endif %}
 </div>
 
 </div>

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -9,6 +9,7 @@ endblock %}
     </h1>
     <form action="{{ url_for(request.endpoint, project_name=project_name) }}" method="GET" class="flex items-center">
         {% if tag_id %}<input type="hidden" name="tag_id" value="{{tag_id}}">{% endif %}
+        {% if signature %}<input type="hidden" name="signature" value="{{signature}}">{% endif %}
         <input type="text" name="search" value="{{search}}" placeholder="Search for crashes"
             class="p-2 border-2 border-gray-300 rounded-md">
         <button type="submit" class="p-2 bg-blue-500 text-white rounded-md">Search</button>
@@ -38,6 +39,13 @@ endblock %}
 <div class="w-5/6 mb-2 text-sm text-gray-600">
     Filtered by tag: <b>{{ active_tag }}</b> &middot;
     <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit) }}" class="text-blue-600 hover:underline">clear</a>
+</div>
+{% endif %}
+
+{% if signature %}
+<div class="w-5/6 mb-2 text-sm text-gray-600">
+    Related crashes matching signature: <b class="font-mono" title="{{ signature }}">{{ signature[:12] }}&hellip;</b> (grouped by stack fingerprint, not AI) &middot;
+    <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit, tag_id=tag_id) }}" class="text-blue-600 hover:underline">clear</a>
 </div>
 {% endif %}
 
@@ -136,13 +144,13 @@ endblock %}
     <div class="w-full text-sm text-left text-gray-500 text-center" style="margin: 50px 0px;">
         <h2>
             {% if offset > 0 %}
-            <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit, offset=offset - limit, tag_id=tag_id) }}" class="p-2 bg-blue-500 text-white rounded-md">
+            <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit, offset=offset - limit, tag_id=tag_id, signature=signature) }}" class="p-2 bg-blue-500 text-white rounded-md">
                 Previous
             </a>
             {% endif %}
             &nbsp; Page {{ (offset // limit) + 1 }} of {{ (full_count // limit) + (1 if full_count % limit > 0 else 0) }} &nbsp;
             {% if offset + limit < full_count %}
-            <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit, offset=offset + limit, tag_id=tag_id) }}" class="p-2 bg-blue-500 text-white rounded-md">
+            <a href="{{ url_for(request.endpoint, project_name=project_name, search=search, limit=limit, offset=offset + limit, tag_id=tag_id, signature=signature) }}" class="p-2 bg-blue-500 text-white rounded-md">
                 Next
             </a>
             {% endif %}

--- a/esp-crash-server/tests/helpers.py
+++ b/esp-crash-server/tests/helpers.py
@@ -25,12 +25,12 @@ def create_device(db_conn, ext_device_id, alias=None):
         return cur.fetchone()[0]
 
 
-def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None, ai_summary=None, date=None):
+def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None, ai_summary=None, date=None, signature=None):
     with db_conn.cursor() as cur:
         cur.execute(
-            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump, ai_summary)
-               VALUES (COALESCE(%s, NOW()), %s, %s, %s, %s, %s, %s) RETURNING crash_id""",
-            (date, project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump, ai_summary),
+            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump, ai_summary, signature)
+               VALUES (COALESCE(%s, NOW()), %s, %s, %s, %s, %s, %s, %s) RETURNING crash_id""",
+            (date, project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump, ai_summary, signature),
         )
         return cur.fetchone()[0]
 

--- a/esp-crash-server/tests/test_ai_tagging.py
+++ b/esp-crash-server/tests/test_ai_tagging.py
@@ -114,6 +114,53 @@ def test_summarize_and_tag_reuses_exact_duplicate_without_calling_api(app, db_co
         assert cur.fetchone()[0] == "watchdog"
 
 
+def test_summarize_and_tag_reuses_signature_duplicate_without_calling_api(app, db_conn, monkeypatch):
+    """Two crashes with different (device-specific) dump text but the same
+    non-AI crash_signature.py fingerprint - the "same bug, different
+    device" case exact-dump matching can't catch."""
+    calls = []
+
+    def fail_if_called(api_key=None):
+        raise AssertionError("Anthropic client should not be constructed for a signature duplicate")
+
+    monkeypatch.setattr(ai_tagging, "Anthropic", fail_if_called)
+
+    helpers.create_project(db_conn, "proj-ai-sig", github_user="alice")
+    device_id = helpers.create_device(db_conn, "dev-ai-sig")
+    shared_signature = "a" * 64
+
+    source_id = helpers.create_crash(
+        db_conn, "proj-ai-sig", "1.0", device_id,
+        dump="device A's dump, addr 0x1111", signature=shared_signature,
+        ai_summary="Watchdog fired in ota_manifest task.",
+    )
+    tag_id = helpers.create_tag(db_conn, "proj-ai-sig", "watchdog")
+    helpers.tag_crash(db_conn, source_id, tag_id)
+
+    new_id = helpers.create_crash(
+        db_conn, "proj-ai-sig", "1.0", device_id,
+        dump="device B's dump, addr 0x2222", signature=shared_signature,
+    )
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(new_id, "proj-ai-sig")
+
+    assert calls == []
+    assert str(source_id) in result
+    assert "Watchdog fired in ota_manifest task." in result
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT t.name FROM tag t JOIN crash_tag ct ON ct.tag_id = t.tag_id WHERE ct.crash_id = %s",
+            (new_id,),
+        )
+        assert cur.fetchone()[0] == "watchdog"
+
+
 def test_summarize_and_tag_ignores_duplicates_from_other_projects(app, db_conn, monkeypatch):
     """Same dump text in a different project must not be treated as a
     duplicate - tags are project-scoped and coincidental content matches

--- a/esp-crash-server/tests/test_crash_signature.py
+++ b/esp-crash-server/tests/test_crash_signature.py
@@ -1,0 +1,96 @@
+"""Tests for app/crash_signature.py. Sample dump text below is trimmed from
+real esp-crash-server crash dumps (addresses/pointers changed, structure and
+function names preserved) - including the actual "same root cause, different
+device" case (a watchdog firing on two different devices) that motivated the
+signature approach in the first place."""
+from app.crash_signature import compute_signature
+
+_WATCHDOG_DEVICE_A = """
+==================== CURRENT THREAD STACK =====================
+#0  panic_abort (details=0x3ffb37ac <port_IntStack+1964> "Watchdog 'ota_manifest' timeout") at /opt/esp/idf/components/esp_system/panic.c:489
+#1  0x4008874c in esp_system_abort (details=0x3ffb37ac <port_IntStack+1964> "Watchdog 'ota_manifest' timeout") at /opt/esp/idf/components/esp_system/port/esp_system_chip.c:87
+#2  0x40114e3c in watchdog_timer_isr_callback (timer=0x3ffd1108, edata=0x3ffb3810 <port_IntStack+2064>, user_ctx=0x3ffb4738 <s_pool+32>) at /root/project/components/watchdog/watchdog.c:330
+#3  0x40086d8b in gptimer_default_isr (args=0x3ffd1108) at /opt/esp/idf/components/esp_driver_gptimer/src/gptimer.c:470
+#4  0x40082b18 in _xt_lowint1 () at /opt/esp/idf/components/xtensa/xtensa_vectors.S:1240
+#5  0x40086ff2 in xt_utils_wait_for_intr () at /opt/esp/idf/components/xtensa/include/xt_utils.h:82
+#6  esp_cpu_wait_for_intr () at /opt/esp/idf/components/esp_hw_support/cpu.c:55
+#7  0x401b87f0 in esp_vApplicationIdleHook () at /opt/esp/idf/components/esp_system/freertos_hooks.c:58
+#8  0x401ba72a in prvIdleTask (pvParameters=0x0) at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/tasks.c:4350
+#9  0x401b9845 in vPortTaskWrapper (pxCode=0x401ba6a8 <prvIdleTask>, pvParameters=0x0) at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:139
+
+======================== THREADS INFO =========================
+"""
+
+# Same bug, different device: identical function-name sequence, different
+# register/timer-handle addresses throughout.
+_WATCHDOG_DEVICE_B = """
+==================== CURRENT THREAD STACK =====================
+#0  panic_abort (details=0x3ffb37ac <port_IntStack+1964> "Watchdog 'ota_manifest' timeout") at /opt/esp/idf/components/esp_system/panic.c:489
+#1  0x4008874c in esp_system_abort (details=0x3ffb37ac <port_IntStack+1964> "Watchdog 'ota_manifest' timeout") at /opt/esp/idf/components/esp_system/port/esp_system_chip.c:87
+#2  0x40114e3c in watchdog_timer_isr_callback (timer=0x3ffd10dc, edata=0x3ffb3810 <port_IntStack+2064>, user_ctx=0x3ffb4738 <s_pool+32>) at /root/project/components/watchdog/watchdog.c:330
+#3  0x40086d8b in gptimer_default_isr (args=0x3ffd10dc) at /opt/esp/idf/components/esp_driver_gptimer/src/gptimer.c:470
+#4  0x40082b18 in _xt_lowint1 () at /opt/esp/idf/components/xtensa/xtensa_vectors.S:1240
+#5  0x40086ff2 in xt_utils_wait_for_intr () at /opt/esp/idf/components/xtensa/include/xt_utils.h:82
+#6  esp_cpu_wait_for_intr () at /opt/esp/idf/components/esp_hw_support/cpu.c:55
+#7  0x401b87f0 in esp_vApplicationIdleHook () at /opt/esp/idf/components/esp_system/freertos_hooks.c:58
+#8  0x401ba72a in prvIdleTask (pvParameters=0x0) at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/tasks.c:4350
+#9  0x401b9845 in vPortTaskWrapper (pxCode=0x401ba6a8 <prvIdleTask>, pvParameters=0x0) at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:139
+
+======================== THREADS INFO =========================
+"""
+
+_MQTT_RETRY_CRASH = """
+==================== CURRENT THREAD STACK =====================
+#0  0x40081fc9 in panic_abort (details=0x3ffd223a "abort() was called at PC 0x4008a3bf on core 0") at /opt/esp/idf/components/esp_system/panic.c:455
+#1  0x4008a3cc in esp_system_abort (details=0x3ffd223a "abort() was called at PC 0x4008a3bf on core 0") at /opt/esp/idf/components/esp_system/esp_system.c:153
+#2  0x400913bc in abort () at /opt/esp/idf/components/newlib/abort.c:38
+#3  0x4008a3c2 in _esp_error_check_failed (rc=-1, file=0x3f40e986 "./common/mqtt.c", line=751, function=0x3f40f2c2 <__func__$2> "retry_connect", expression=0x3f40eb87 "esp_mqtt_client_start(mqtt_client)") at /opt/esp/idf/components/esp_system/esp_err.c:47
+#4  0x400e9d22 in retry_connect () at /root/project/common/mqtt.c:751
+#5  0x400ea71d in mqtt_watch_thread (pvParameters=<optimized out>) at /root/project/common/mqtt.c:805
+#6  0x4008a3dc in vPortTaskWrapper (pxCode=0x400ea6b4 <mqtt_watch_thread>, pvParameters=0x0) at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:149
+
+======================== THREADS INFO =========================
+"""
+
+_DECODE_FAILURE = (
+    "espcoredump.py v1.16.0\n"
+    "Failed to load core dump: Invalid application image for coredump: "
+    "coredump SHA256(7ee9b037d904b0f9) != app SHA256(3fc0bb573327c831).\n"
+)
+
+
+def test_same_bug_different_device_gets_same_signature():
+    assert compute_signature(_WATCHDOG_DEVICE_A) == compute_signature(_WATCHDOG_DEVICE_B)
+
+
+def test_different_bugs_get_different_signatures():
+    assert compute_signature(_WATCHDOG_DEVICE_A) != compute_signature(_MQTT_RETRY_CRASH)
+
+
+def test_signature_is_a_nonempty_hex_string():
+    sig = compute_signature(_MQTT_RETRY_CRASH)
+    assert sig is not None
+    assert len(sig) == 64
+    assert all(c in "0123456789abcdef" for c in sig)
+
+
+def test_dump_without_parseable_backtrace_returns_none():
+    assert compute_signature(_DECODE_FAILURE) is None
+
+
+def test_empty_or_missing_dump_returns_none():
+    assert compute_signature("") is None
+    assert compute_signature(None) is None
+
+
+def test_frame_without_address_prefix_is_still_parsed():
+    # gdb omits the "0xADDR in" prefix for some frames (e.g. #0, or a frame
+    # gdb resolved purely from the symbol table) - both dumps above already
+    # exercise this (#0 and #6 in the watchdog dumps), this test pins it
+    # down explicitly against a minimal single-frame case.
+    dump = (
+        "==================== CURRENT THREAD STACK =====================\n"
+        "#0  esp_cpu_wait_for_intr () at /opt/esp/idf/components/esp_hw_support/cpu.c:55\n"
+        "======================== THREADS INFO =========================\n"
+    )
+    assert compute_signature(dump) is not None

--- a/esp-crash-server/tests/test_cron.py
+++ b/esp-crash-server/tests/test_cron.py
@@ -45,6 +45,76 @@ def test_cron_processes_pending_crash(client, db_conn, monkeypatch):
         assert "base panic text" in cur.fetchone()[0]
 
 
+_STACK_TEXT = (
+    "==================== CURRENT THREAD STACK =====================\n"
+    "#0  panic_abort (details=0x3ffb37ac) at panic.c:489\n"
+    "#1  0x4008874c in esp_system_abort (details=0x3ffb37ac) at esp_system_chip.c:87\n"
+    "#2  0x40114e3c in watchdog_timer_isr_callback (timer=0x3ffd1108) at watchdog.c:330\n"
+    "======================== THREADS INFO =========================\n"
+)
+
+
+def _fake_resolve_with_stack(dump_path, prog_path):
+    fd, core_elf = tempfile.mkstemp()
+    os.close(fd)
+    return ([], [], _STACK_TEXT, core_elf, [])
+
+
+def test_cron_computes_signature_on_symbolication(client, db_conn, monkeypatch):
+    from app import decode
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fake_resolve_with_stack)
+
+    device_id = helpers.create_device(db_conn, "dev-cron-sig")
+    helpers.create_elf_file(db_conn, "proj-cron-sig", "1.0")
+    crash_id = helpers.create_crash(db_conn, "proj-cron-sig", "1.0", device_id, crash_dmp=b"raw-dump")
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT signature FROM crash WHERE crash_id = %s", (crash_id,))
+        signature = cur.fetchone()[0]
+        assert signature is not None
+        assert len(signature) == 64
+
+
+def test_cron_backfills_signature_for_already_symbolicated_crashes(client, db_conn, monkeypatch):
+    from app import decode
+
+    # Backfill must not re-run symbolication - if it did, this would blow up.
+    def _fail(*a, **k):
+        raise AssertionError("backfill should not re-symbolicate")
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", _fail)
+
+    device_id = helpers.create_device(db_conn, "dev-cron-sig-backfill")
+    crash_id = helpers.create_crash(
+        db_conn, "proj-cron-sig-backfill", "1.0", device_id, dump=_STACK_TEXT,
+    )
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT signature FROM crash WHERE crash_id = %s", (crash_id,))
+        assert cur.fetchone()[0] is not None
+
+
+def test_cron_backfill_leaves_unparseable_dump_signature_null(client, db_conn):
+    device_id = helpers.create_device(db_conn, "dev-cron-sig-unparseable")
+    crash_id = helpers.create_crash(
+        db_conn, "proj-cron-sig-unparseable", "1.0", device_id, dump="Failed to load core dump.",
+    )
+
+    resp = client.get("/cron")
+    assert resp.status_code == 200
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT signature FROM crash WHERE crash_id = %s", (crash_id,))
+        assert cur.fetchone()[0] is None
+
+
 def test_cron_sends_webhook(client, db_conn, monkeypatch):
     import requests
     from app import decode

--- a/esp-crash-server/tests/test_routes_crashes.py
+++ b/esp-crash-server/tests/test_routes_crashes.py
@@ -38,6 +38,29 @@ def test_refresh_crash_clears_dump_and_redirects(client, db_conn):
         assert cur.fetchone()[0] is None
 
 
+def test_show_project_crash_shows_related_link_when_signature_set(client, db_conn):
+    helpers.create_project(db_conn, "proj-c7", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-c7")
+    sig = "d" * 64
+    crash_id = helpers.create_crash(db_conn, "proj-c7", "1.0", device_id, dump="dump text", signature=sig)
+
+    resp = client.get(f"/projects/proj-c7/{crash_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert f"/crash?signature={sig}" in body
+    assert "Related" in body
+
+
+def test_show_project_crash_hides_related_link_without_signature(client, db_conn):
+    helpers.create_project(db_conn, "proj-c8", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-c8")
+    crash_id = helpers.create_crash(db_conn, "proj-c8", "1.0", device_id, dump="dump text")
+
+    resp = client.get(f"/projects/proj-c8/{crash_id}")
+    assert resp.status_code == 200
+    assert b"signature=" not in resp.data
+
+
 def test_show_project_crash_renders_ai_summary(client, db_conn):
     helpers.create_project(db_conn, "proj-c6", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-c6")

--- a/esp-crash-server/tests/test_routes_projects.py
+++ b/esp-crash-server/tests/test_routes_projects.py
@@ -52,6 +52,40 @@ def test_list_crashes_all_projects(client, db_conn):
     assert b"dev-3" in resp.data
 
 
+def test_list_project_crashes_signature_filter(client, db_conn):
+    helpers.create_project(db_conn, "proj-sig", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-sig")
+    sig = "b" * 64
+    helpers.create_crash(db_conn, "proj-sig", "1.0", device_id, signature=sig)
+    helpers.create_crash(db_conn, "proj-sig", "1.0", device_id)  # no signature - must not match
+
+    resp = client.get(f"/projects/proj-sig?signature={sig}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "Related crashes matching signature" in body
+    assert sig[:12] in body
+
+
+def test_list_crashes_signature_filter_spans_projects(client, db_conn):
+    """The Related link on the crash page points at the global /crash
+    listing (not a per-project one) - a signature match must be found
+    regardless of which project it's in."""
+    sig = "c" * 64
+    helpers.create_project(db_conn, "proj-sig-a", github_user="none")
+    device_a = helpers.create_device(db_conn, "dev-sig-a")
+    helpers.create_crash(db_conn, "proj-sig-a", "1.0", device_a, signature=sig)
+
+    helpers.create_project(db_conn, "proj-sig-b", github_user="none")
+    device_b = helpers.create_device(db_conn, "dev-sig-b")
+    helpers.create_crash(db_conn, "proj-sig-b", "1.0", device_b, signature=sig)
+
+    resp = client.get(f"/crash?signature={sig}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "proj-sig-a" in body
+    assert "proj-sig-b" in body
+
+
 def test_list_builds_empty(client, db_conn):
     helpers.create_project(db_conn, "proj-b", github_user="none")
     resp = client.get("/projects/proj-b/builds")


### PR DESCRIPTION
## Summary
- New `app/crash_signature.py`: fingerprints a symbolicated crash by parsing the GDB `CURRENT THREAD STACK` backtrace, dropping addresses/register/argument values (always device/run-specific) and generic wrapper frames (`panic_abort`, `esp_system_abort`, `abort`, `vPortTaskWrapper`), then SHA256-hashing the remaining ordered function-name sequence. No LLM call - pure local computation.
- Validated directly against real production crash dumps, including the actual "same `ota_manifest` watchdog, different device" pair that the existing exact-dump dedup can't catch (identical signature for both, distinct from unrelated crashes).
- New indexed `Crash.signature` column, computed at symbolication time (`app/routes/cron.py`) and backfilled for the existing ~62k-row backlog via a cheap batched cron pass - no external calls, so (unlike the AI step) there's no cost/backlog-explosion risk in it re-running.
- `app/ai_tagging.py` gets a second dedup tier below the exact-dump check: same signature + same project + already summarized -> copy the summary/tags, skip the API call entirely. This is the actual cost-cutting mechanism the user asked for.
- UI: a "Related" link on the crash detail page (next to Device/Download/Build/Project) opens the global `/crash` listing filtered to `?signature=...` - mirrors the existing `?tag_id=...` filter, spans all the user's accessible projects, shown only when a crash has a computed signature.

## Test plan
- [x] Full `pytest` suite green (171 passed, 1 skipped), including new `tests/test_crash_signature.py` (same-bug-different-device match, different-bug mismatch, unparseable-dump → None, frame-without-address parsing) and coverage in `test_cron.py` (signature computed at symbolication, backfill runs without re-symbolicating, unparseable dumps stay NULL), `test_ai_tagging.py` (signature-tier dedup skips the API call), and `test_routes_projects.py`/`test_routes_crashes.py` (the `?signature=` filter and the Related link's presence/absence).
- [ ] After merge: deploy + migrate, then spot-check the "Related" link against a few real `ota_manifest`-style duplicate crashes once the backlog backfill catches up.