### PR TITLE
Run cron locally instead of curling the backend webserver

### DIFF
--- a/esp-crash-server/Dockerfile
+++ b/esp-crash-server/Dockerfile
@@ -80,6 +80,9 @@ COPY alembic/ alembic/
 # MCP server (run via `uvicorn mcp_server:app`).
 COPY mcp_server.py .
 COPY mcp_app/ mcp_app/
+# Cron sidecar (run via `python cron_runner.py`, see docker-compose.yml's
+# `cron` service).
+COPY cron_runner.py .
 
 ENV FLASK_APP=server.py
 ENV FLASK_RUN_PORT=8000

--- a/esp-crash-server/cron_runner.py
+++ b/esp-crash-server/cron_runner.py
@@ -1,0 +1,55 @@
+"""Standalone process behind the `cron` docker-compose service.
+
+Historically this container just looped `curl backend:8000/cron` every 10s,
+meaning app/routes/cron.py's actual logic ran inside the `backend` gunicorn
+workers and its log lines showed up under backend's log stream. This calls
+app.routes.cron.cron() directly instead - no HTTP round trip, no dependency
+on `backend` being reachable, and cron's own log lines now show up under
+this process's own stdout/stderr (captured by the `cron` service's own
+logging driver - see docker-compose.yml), using the exact same
+logging.basicConfig() setup as the web app (app.create_app()) so the format
+is identical.
+
+Run with: python cron_runner.py
+
+Logs via app.logger (current_app.logger inside the app context), same as
+every other module in this codebase (app/routes/cron.py included) - not a
+module-level logging.getLogger(__name__) - so it's created lazily the same
+way and picked up by the same logging.basicConfig() setup from
+app.create_app(), rather than as a standalone logger that could exist
+before that setup runs.
+"""
+import os
+import time
+
+from app import create_app
+from app.routes.cron import cron as run_cron
+
+INTERVAL_SECONDS = int(os.environ.get("CRON_INTERVAL_SECONDS", "10"))
+
+
+def _tick(app):
+    """Run one cron pass inside a fresh app context. Exceptions are caught
+    and logged, not raised - a single bad tick (e.g. a transient DB hiccup)
+    must not take the whole process down, and the next tick just retries.
+    Exiting the `with` block runs Flask-SQLAlchemy's teardown handler
+    (db.session.remove()) whether or not the tick raised, so a failed tick
+    can't leave a dangling transaction for the next one - the same
+    guarantee a normal HTTP request gets."""
+    with app.app_context():
+        try:
+            run_cron()
+        except Exception:
+            app.logger.exception("cron tick failed")
+
+
+def main():
+    app = create_app()
+    app.logger.info("cron runner starting (interval=%ss)", INTERVAL_SECONDS)
+    while True:
+        time.sleep(INTERVAL_SECONDS)
+        _tick(app)
+
+
+if __name__ == "__main__":
+    main()

--- a/esp-crash-server/tests/test_cron_runner.py
+++ b/esp-crash-server/tests/test_cron_runner.py
@@ -1,0 +1,82 @@
+"""Tests for cron_runner.py - the standalone process behind the `cron`
+docker-compose service (calls app.routes.cron.cron() directly instead of
+looping `curl backend:8000/cron`). Most tests here monkeypatch run_cron so
+they don't duplicate app/routes/cron.py's own tests (tests/test_cron.py) -
+one end-to-end test below exercises the real, unmocked path."""
+import logging
+import os
+import tempfile
+
+import cron_runner
+import helpers
+
+
+def test_tick_processes_a_real_pending_crash_end_to_end(app, db_conn, monkeypatch):
+    """No mocking of run_cron - proves _tick actually drives the real
+    app.routes.cron.cron() logic against the DB, the same as the old
+    `curl backend:8000/cron` path did."""
+    from app import decode
+
+    def fake_resolve(dump_path, prog_path):
+        fd, core_elf = tempfile.mkstemp()
+        os.close(fd)
+        return ([], [], "base panic text\n", core_elf, [])
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", fake_resolve)
+
+    device_id = helpers.create_device(db_conn, "dev-cron-runner-e2e")
+    helpers.create_elf_file(db_conn, "proj-cron-runner-e2e", "1.0")
+    crash_id = helpers.create_crash(
+        db_conn, "proj-cron-runner-e2e", "1.0", device_id, crash_dmp=b"raw-dump",
+    )
+
+    cron_runner._tick(app)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT dump FROM crash WHERE crash_id = %s", (crash_id,))
+        assert "base panic text" in cur.fetchone()[0]
+
+
+def test_tick_runs_cron_inside_an_app_context(app, monkeypatch):
+    from flask import current_app
+
+    calls = []
+
+    def fake_cron():
+        calls.append(current_app.name)
+        return "OK\n", 200
+
+    monkeypatch.setattr(cron_runner, "run_cron", fake_cron)
+    cron_runner._tick(app)
+
+    assert calls == [app.name]
+
+
+def test_tick_catches_and_logs_exceptions_without_raising(app, monkeypatch, caplog):
+    def boom():
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(cron_runner, "run_cron", boom)
+
+    with caplog.at_level(logging.ERROR, logger=app.logger.name):
+        cron_runner._tick(app)  # must not raise
+
+    assert "cron tick failed" in caplog.text
+
+
+def test_tick_failure_does_not_leave_a_dangling_session(app, monkeypatch):
+    """A failed tick must still tear down the app context (and with it,
+    Flask-SQLAlchemy's db.session.remove()) so the next tick starts clean -
+    same guarantee a normal HTTP request gets on exception."""
+    from app.models import db
+
+    def boom():
+        # Touch the session before blowing up, like a real query would.
+        db.session.execute(db.text("SELECT 1"))
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cron_runner, "run_cron", boom)
+    cron_runner._tick(app)
+
+    with app.app_context():
+        assert not db.session.registry.has()


### PR DESCRIPTION
## Summary
- New `cron_runner.py`: builds the same Flask app (`app.create_app()`) used by `server.py`, then loops calling `app.routes.cron.cron()` directly inside an app context - no HTTP round trip, no dependency on `backend` being reachable.
- Replaces the `cron` sidecar's `while sleep 10; do curl -s 'backend:8000/cron'; done` loop. That loop meant cron's actual logic only ever executed inside `backend`'s gunicorn workers - the `cron` container's own logs were just curl's (suppressed) output.
- Logs via `app.logger` (i.e. `current_app.logger`), matching how every other module in this codebase logs - not a module-level `logging.getLogger(__name__)`. Cron's log lines now show up under the `cron` container's own log stream, same format as the web app.
- A failed tick is caught and logged rather than crashing the process; exiting the per-tick app context still runs Flask-SQLAlchemy's teardown (`db.session.remove()`), so a bad tick can't leave a dangling transaction for the next one - same guarantee a normal HTTP request gets on exception.
- The Flask `/cron` route itself is untouched (still useful for manual triggering, and it's what `tests/test_cron.py` exercises); only the `cron` service's own container entrypoint changes.

Deploy-time only, not in this PR: docker-compose.yml's `cron` service `command:` needs to change from the curl loop to `python cron_runner.py`.

## Test plan
- [x] Full `pytest` suite green (175 passed, 1 skipped), including new `tests/test_cron_runner.py`: an end-to-end tick with no mocking (proves it drives the real cron() logic against the DB), that `_tick` runs inside a real app context, that a failing tick is caught/logged instead of raised, and that a failed tick still tears down the SQLAlchemy session.
- [ ] After merge: flip the `cron` service's command in docker-compose.yml and redeploy, then confirm `docker logs cron` shows the app-formatted log lines that used to only appear in `docker logs backend`.