### PR TITLE
cron_runner: fixed-rate scheduling instead of fixed-delay

### DIFF
--- a/esp-crash-server/cron_runner.py
+++ b/esp-crash-server/cron_runner.py
@@ -43,11 +43,22 @@ def _tick(app):
             app.logger.exception("cron tick failed")
 
 
+def _sleep_remaining(elapsed_since_last_run):
+    """Seconds left to wait before the next tick, given how long it's been
+    since the last one *started* - 0 (never negative) once that alone
+    already used up the whole interval, so a slow tick is followed
+    immediately by the next one instead of a slow tick PLUS a full extra
+    wait on top."""
+    return max(0.0, INTERVAL_SECONDS - elapsed_since_last_run)
+
+
 def main():
     app = create_app()
     app.logger.info("cron runner starting (interval=%ss)", INTERVAL_SECONDS)
+    last_run = time.monotonic()
     while True:
-        time.sleep(INTERVAL_SECONDS)
+        time.sleep(_sleep_remaining(time.monotonic() - last_run))
+        last_run = time.monotonic()
         _tick(app)
 
 

--- a/esp-crash-server/tests/test_cron_runner.py
+++ b/esp-crash-server/tests/test_cron_runner.py
@@ -37,6 +37,20 @@ def test_tick_processes_a_real_pending_crash_end_to_end(app, db_conn, monkeypatc
         assert "base panic text" in cur.fetchone()[0]
 
 
+def test_sleep_remaining_is_full_interval_when_last_run_was_instant():
+    assert cron_runner._sleep_remaining(0) == cron_runner.INTERVAL_SECONDS
+
+
+def test_sleep_remaining_shrinks_by_how_long_the_last_run_took():
+    assert cron_runner._sleep_remaining(3) == cron_runner.INTERVAL_SECONDS - 3
+
+
+def test_sleep_remaining_is_zero_not_negative_when_last_run_was_slow():
+    """A tick that alone took longer than the interval must not also incur
+    a full extra sleep on top - the next tick should fire right away."""
+    assert cron_runner._sleep_remaining(cron_runner.INTERVAL_SECONDS + 5) == 0
+
+
 def test_tick_runs_cron_inside_an_app_context(app, monkeypatch):
     from flask import current_app
 


### PR DESCRIPTION
## Summary
- `cron_runner.main()`'s loop used to always `time.sleep(INTERVAL_SECONDS)` after each tick regardless of how long the tick itself took (fixed-delay) - a slow tick pushed every following one later by that same amount, compounding over time.
- Now tracks when the last tick *started* and only sleeps the remaining portion of the interval (`_sleep_remaining`, clamped to 0). Once a tick alone has already used up the whole interval, the next one fires immediately instead of waiting a full extra interval on top.

## Test plan
- [x] Full `pytest` suite green (178 passed, 1 skipped), including 3 new unit tests for `_sleep_remaining` (full interval when instant, shrinks by elapsed time, clamps to 0 - never negative - when the run alone exceeded the interval).
- [ ] After merge: redeploy and confirm `docker logs cron` still ticks normally (no behavior difference under the current light DB backfill load, this only matters once a tick approaches/exceeds the 10s interval).