### PR TITLE
Show a Related(x) link per crash on the list page

### DIFF
--- a/esp-crash-server/app/routes/projects.py
+++ b/esp-crash-server/app/routes/projects.py
@@ -45,6 +45,7 @@ def list_project_crashes(project_name):
             Crash.device_id,
             Crash.project_ver,
             Crash.module_names,
+            Crash.signature,
             func.array_agg(ElfFile.elf_file_id).filter(ElfFile.elf_file_id.isnot(None)).label("elf_file_id"),
             func.array_agg(ElfFile.project_alias).label("project_alias"),
             Device.ext_device_id,
@@ -64,6 +65,7 @@ def list_project_crashes(project_name):
             Crash.project_name,
             Crash.device_id,
             Crash.project_ver,
+            Crash.signature,
             Device.ext_device_id,
             Device.alias,
             ProjectSettings.device_url_template,
@@ -89,7 +91,33 @@ def list_project_crashes(project_name):
             tags_by_crash.setdefault(t["crash_id"], []).append(
                 {"tag_id": t["tag_id"], "name": t["name"], "description": t["description"]}
             )
-    crashes = [dict(c, tags=tags_by_crash.get(c["crash_id"], [])) for c in crashes]
+    # Related-crash counts (non-AI, see app/crash_signature.py) - batched the
+    # same way as tags above rather than folded into the aggregate query.
+    # count(distinct crash_id) because the ProjectAuth join above can fan
+    # out per crash when a project has more than one ACL row (or in
+    # no-auth mode, where every ProjectAuth row for a project matches) -
+    # a plain count() would overcount in exactly those cases.
+    signatures = {c["signature"] for c in crashes if c["signature"]}
+    related_counts = {}
+    if signatures:
+        related_rows = db.session.execute(
+            select(Crash.signature, func.count(func.distinct(Crash.crash_id)).label("cnt"))
+            .select_from(Crash)
+            .join(ProjectAuth, Crash.project_name == ProjectAuth.project_name)
+            .where(Crash.signature.in_(signatures), auth_filter(ProjectAuth.github))
+            .group_by(Crash.signature)
+        ).mappings().all()
+        related_counts = {r["signature"]: r["cnt"] for r in related_rows}
+
+    crashes = [
+        dict(
+            c,
+            tags=tags_by_crash.get(c["crash_id"], []),
+            # -1 to exclude the crash itself from its own related count.
+            related_count=max(0, related_counts.get(c["signature"], 0) - 1) if c["signature"] else 0,
+        )
+        for c in crashes
+    ]
 
     active_tag = None
     if tag_id:

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -61,6 +61,7 @@ endblock %}
                 <th scope="col" class="px-6 py-3">Device Id</th>
                 <th scope="col" class="px-6 py-3">Modules</th>
                 <th scope="col" class="px-6 py-3">Tags</th>
+                <th scope="col" class="px-6 py-3">Related</th>
                 <th scope="col" class="px-6 py-3"></th>
             </tr>
         </thead>
@@ -122,6 +123,17 @@ endblock %}
                         </a>
                         {% endfor %}
                     </div>
+                    {% else %}
+                    <span class="text-gray-300">&mdash;</span>
+                    {% endif %}
+                </td>
+                <td class="px-6 py-4">
+                    {% if crash.related_count > 0 %}
+                    <a href="{{ url_for('list_crashes', signature=crash.signature) }}"
+                       class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-sky-100 text-sky-800 hover:bg-sky-200"
+                       title="Other crashes with the same stack signature (no AI involved)">
+                        Related({{ crash.related_count }})
+                    </a>
                     {% else %}
                     <span class="text-gray-300">&mdash;</span>
                     {% endif %}

--- a/esp-crash-server/tests/test_routes_projects.py
+++ b/esp-crash-server/tests/test_routes_projects.py
@@ -86,6 +86,51 @@ def test_list_crashes_signature_filter_spans_projects(client, db_conn):
     assert "proj-sig-b" in body
 
 
+def test_list_project_crashes_shows_related_link_with_count(client, db_conn):
+    helpers.create_project(db_conn, "proj-related", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-related")
+    sig = "e" * 64
+    helpers.create_crash(db_conn, "proj-related", "1.0", device_id, signature=sig)
+    helpers.create_crash(db_conn, "proj-related", "1.0", device_id, signature=sig)
+    helpers.create_crash(db_conn, "proj-related", "1.0", device_id, signature=sig)
+
+    resp = client.get("/projects/proj-related")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    # Each of the 3 crashes shares its signature with the other 2.
+    assert body.count("Related(2)") == 3
+    assert f"signature={sig}" in body
+
+
+def test_list_project_crashes_hides_related_link_without_duplicates(client, db_conn):
+    helpers.create_project(db_conn, "proj-no-related", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-no-related")
+    # A signature with no other crash sharing it, and a crash with no
+    # signature at all - neither should render a Related link.
+    helpers.create_crash(db_conn, "proj-no-related", "1.0", device_id, signature="f" * 64)
+    helpers.create_crash(db_conn, "proj-no-related", "1.0", device_id)
+
+    resp = client.get("/projects/proj-no-related")
+    assert resp.status_code == 200
+    assert "Related(" not in resp.data.decode()
+
+
+def test_related_count_not_inflated_by_multiple_acl_grants(client, db_conn):
+    """A project with more than one project_auth row (multiple users
+    granted access) must not fan-out the related-crash count - regression
+    test for the ProjectAuth join used to compute it."""
+    helpers.create_project(db_conn, "proj-related-multi-acl", github_user="alice")
+    helpers.create_project(db_conn, "proj-related-multi-acl", github_user="bob")
+    device_id = helpers.create_device(db_conn, "dev-related-multi-acl")
+    sig = "1" * 64
+    helpers.create_crash(db_conn, "proj-related-multi-acl", "1.0", device_id, signature=sig)
+    helpers.create_crash(db_conn, "proj-related-multi-acl", "1.0", device_id, signature=sig)
+
+    resp = client.get("/projects/proj-related-multi-acl")
+    assert resp.status_code == 200
+    assert "Related(1)" in resp.data.decode()
+
+
 def test_list_builds_empty(client, db_conn):
     helpers.create_project(db_conn, "proj-b", github_user="none")
     resp = client.get("/projects/proj-b/builds")


### PR DESCRIPTION
## Summary
- New "Related" column on the crash list page (`templates/project.html`) - each row with a computed signature (see `app/crash_signature.py`, added earlier for non-AI duplicate grouping) shows a `Related(x)` link, x being the count of *other* crashes sharing that signature. Links to the existing `/crash?signature=...` listing, same target the crash detail page's "Related" link already uses.
- Rows with no signature, or a signature no other crash shares, show a plain dash instead - consistent with how the Modules/Tags columns already handle the empty case.
- Counts are computed with one batched query (same idiom as the existing tags-batching query right above it) using `count(distinct crash_id)`, not a plain `count()` - the `ProjectAuth` join already used for ACL scoping can fan out per crash when a project has more than one ACL row (or, in no-auth mode, every `ProjectAuth` row for a project matches), which would otherwise overcount.

## Test plan
- [x] Full `pytest` suite green (181 passed, 1 skipped), including new coverage: the link renders with the correct count for a 3-way duplicate cluster, it's hidden for both a unique signature and a missing signature, and a regression test pinning down the multi-ACL-row overcounting fix (2 crashes sharing a signature in a project with 2 ACL grants must still show `Related(1)`, not `Related(3)`).