### PR TITLE
Move Related(x) link into the action links cell

### DIFF
--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -3,10 +3,10 @@
 {% block content %}
 
 <div class="flex">
-    <h1 class="mb-3 text-3xl leading-none text-slate-900 w-3/6">
+    <h1 class="mb-3 text-3xl leading-none text-slate-900 w-2/6">
         Crash report <b>{{ crash.project_name }}</b> <b>#{{ crash.crash_id }}</b>
     </h1>
-    <div class="w-2/6 flex flex-wrap justify-end items-center">
+    <div class="w-4/6 flex flex-wrap justify-end items-center">
     <a href="{{ url_for('show_device', device_id=crash.device_id) }}" class="flex items-center p-4 ">
         <svg class="w-6 h-6 stroke-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <rect x="5" y="3" width="14" height="18" rx="2" ry="2"></rect>
@@ -83,7 +83,7 @@
 </div>
 
 {% if crash.ai_summary %}
-<div class="w-5/6 mt-4 p-4 bg-indigo-50 border border-indigo-100 rounded-lg text-sm text-slate-700 italic">
+<div class="w-5/6 mt-4 p-4 bg-indigo-50 border border-indigo-100 rounded-lg text-sm text-slate-700 italic whitespace-pre-line">
     {{ crash.ai_summary }}
 </div>
 {% endif %}

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -61,7 +61,6 @@ endblock %}
                 <th scope="col" class="px-6 py-3">Device Id</th>
                 <th scope="col" class="px-6 py-3">Modules</th>
                 <th scope="col" class="px-6 py-3">Tags</th>
-                <th scope="col" class="px-6 py-3">Related</th>
                 <th scope="col" class="px-6 py-3"></th>
             </tr>
         </thead>
@@ -128,23 +127,19 @@ endblock %}
                     {% endif %}
                 </td>
                 <td class="px-6 py-4">
-                    {% if crash.related_count > 0 %}
-                    <a href="{{ url_for('list_crashes', signature=crash.signature) }}"
-                       class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-sky-100 text-sky-800 hover:bg-sky-200"
-                       title="Other crashes with the same stack signature (no AI involved)">
-                        Related({{ crash.related_count }})
-                    </a>
-                    {% else %}
-                    <span class="text-gray-300">&mdash;</span>
-                    {% endif %}
-                </td>
-                <td class="px-6 py-4">
                     <a href="{{ url_for('delete_crash', project_name=crash.project_name, crash_id=crash.crash_id) }}" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Delete</a>
                     <a href="{{ url_for('show_device', device_id=crash.device_id) }}" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Device</a>
                     {% if crash.elf_file_id %}
                     {% for elf_file_id in crash.elf_file_id %}
                     <a href="{{ url_for('show_build', build_id=elf_file_id) }}" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Build</a>
                     {% endfor %}
+                    {% endif %}
+                    {% if crash.related_count > 0 %}
+                    <a href="{{ url_for('list_crashes', signature=crash.signature) }}"
+                       class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+                       title="Other crashes with the same stack signature (no AI involved)">
+                        Related({{ crash.related_count }})
+                    </a>
                     {% endif %}
                 </td>
             </tr>

--- a/esp-crash-server/tests/test_routes_crashes.py
+++ b/esp-crash-server/tests/test_routes_crashes.py
@@ -73,6 +73,23 @@ def test_show_project_crash_renders_ai_summary(client, db_conn):
     assert b"This crash is a stack overflow." in resp.data
 
 
+def test_show_project_crash_ai_summary_preserves_newlines(client, db_conn):
+    """The AI summary is prose Claude wrote with its own line breaks -
+    plain HTML collapses those, so the summary block needs a whitespace
+    CSS class that actually renders them."""
+    helpers.create_project(db_conn, "proj-c7-ai-nl", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-c7-ai-nl")
+    crash_id = helpers.create_crash(
+        db_conn, "proj-c7-ai-nl", "1.0", device_id,
+        dump="dump text", ai_summary="First line.\nSecond line.",
+    )
+    resp = client.get(f"/projects/proj-c7-ai-nl/{crash_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "First line.\nSecond line." in body
+    assert "whitespace-pre-line" in body
+
+
 def test_show_project_crash_omits_ai_summary_block_when_absent(client, db_conn):
     helpers.create_project(db_conn, "proj-c7", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-c7")


### PR DESCRIPTION
## Summary
- The `Related(x)` link added in #28 had its own table column; moved it into the same cell as Delete/Device/Build (styled to match those links) per feedback, and removed the now-unused standalone "Related" column/header.
- Crash detail page: the header's icon-link row (Device/Download/Build/Project/Related) was cramped into a 2/6-width container next to a 3/6-width title, so the 5th item (Related) wrapped onto its own line. Widened the icon-link container to 4/6 (title to 2/6) so it fits on one row.
- Crash detail page: the AI summary block rendered as one unbroken line - plain HTML collapses the newlines in Claude's own prose formatting. Added `whitespace-pre-line` so line breaks actually render.
- No backend/query changes in any of the above - all three are template-only.

## Test plan
- [x] Full `pytest` suite green (182 passed, 1 skipped): existing coverage from #28 still passes (link text/count assertions, not column position), plus a new test asserting the AI summary block preserves `\n` and carries the `whitespace-pre-line` class.
- [ ] Layout changes (header row fitting, related-link placement) are CSS/width tweaks I reasoned through but could not visually verify in a real browser in this environment - worth a quick look after deploy.