### PR TITLE
Hide new-tag fields until '+ New tag...' is picked in the dropdown

### DIFF
--- a/esp-crash-server/app/routes/tags.py
+++ b/esp-crash-server/app/routes/tags.py
@@ -24,8 +24,14 @@ def add_crash_tag(project_name, crash_id):
 
     # A typed new-tag name takes priority over whatever's selected in the
     # existing-tags dropdown, so picking a tag then also typing a new one
-    # does what it looks like it does.
-    tag_name = (request.form.get('new_tag_name') or request.form.get('tag_name') or '').strip()
+    # does what it looks like it does. '__new_tag__' is the "+ New tag..."
+    # option's value (a UI sentinel that reveals the name/description
+    # fields client-side) - it must never be used as an actual tag name if
+    # submitted without new_tag_name filled in.
+    selected_tag = (request.form.get('tag_name') or '').strip()
+    if selected_tag == '__new_tag__':
+        selected_tag = ''
+    tag_name = (request.form.get('new_tag_name') or selected_tag or '').strip()
     if not tag_name:
         return "Missing tag_name", 400
     tag_description = (request.form.get('tag_description') or '').strip() or None

--- a/esp-crash-server/templates/crash.html
+++ b/esp-crash-server/templates/crash.html
@@ -99,19 +99,38 @@
         </span>
         {% endfor %}
         <form method="post" action="{{ url_for('add_crash_tag', project_name=crash.project_name, crash_id=crash.crash_id) }}" class="flex items-center gap-1">
-            <select name="tag_name" class="p-1 text-sm uppercase border-2 border-gray-300 rounded-md">
+            <select name="tag_name" id="tag-select" class="p-1 text-sm uppercase border-2 border-gray-300 rounded-md">
                 <option value="">Select existing tag&hellip;</option>
                 {% for t in project_tags %}
                 <option value="{{ t.name }}" title="{{ t.description or '' }}">{{ t.name }}</option>
                 {% endfor %}
+                <option value="__new_tag__">+ New tag&hellip;</option>
             </select>
-            <span class="text-xs text-gray-400">or</span>
-            <input type="text" name="new_tag_name" placeholder="New tag name" class="p-1 text-sm border-2 border-gray-300 rounded-md">
-            <input type="text" name="tag_description" placeholder="Description (new tags only)" class="p-1 text-sm border-2 border-gray-300 rounded-md">
+            <span id="new-tag-fields" class="items-center gap-1" style="display:none">
+                <input type="text" name="new_tag_name" placeholder="New tag name" class="p-1 text-sm border-2 border-gray-300 rounded-md">
+                <input type="text" name="tag_description" placeholder="Description" class="p-1 text-sm border-2 border-gray-300 rounded-md">
+            </span>
             <button type="submit" class="p-1 px-2 text-sm bg-blue-500 text-white rounded-md">Add</button>
         </form>
     </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var select = document.getElementById('tag-select');
+    var newTagFields = document.getElementById('new-tag-fields');
+    if (!select || !newTagFields) return;
+    function sync() {
+        var isNewTag = select.value === '__new_tag__';
+        newTagFields.style.display = isNewTag ? 'inline-flex' : 'none';
+        if (!isNewTag) {
+            newTagFields.querySelectorAll('input').forEach(function (input) { input.value = ''; });
+        }
+    }
+    select.addEventListener('change', sync);
+    sync();
+});
+</script>
 
 {% if modules %}
 <div class="w-5/6 mt-4">

--- a/esp-crash-server/tests/test_routes_tags.py
+++ b/esp-crash-server/tests/test_routes_tags.py
@@ -50,6 +50,41 @@ def test_add_crash_tag_new_tag_name_takes_priority(client, db_conn):
         assert cur.fetchone()[0] == "brand new"
 
 
+def test_add_crash_tag_new_tag_sentinel_uses_typed_name(client, db_conn):
+    """Selecting the "+ New tag..." option submits tag_name=__new_tag__
+    alongside the typed new_tag_name - the sentinel itself must never
+    become the tag name."""
+    helpers.create_project(db_conn, "proj-t1c", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t1c")
+    crash_id = helpers.create_crash(db_conn, "proj-t1c", "1.0", device_id)
+
+    resp = client.post(
+        f"/projects/proj-t1c/{crash_id}/tags",
+        data={"tag_name": "__new_tag__", "new_tag_name": "Flaky Sensor"},
+    )
+    assert resp.status_code == 302
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT name FROM tag WHERE project_name = %s", ("proj-t1c",))
+        assert cur.fetchone() == ("flaky sensor",)
+
+
+def test_add_crash_tag_new_tag_sentinel_without_typed_name_is_missing(client, db_conn):
+    """The sentinel alone (JS didn't run, or the field was left empty) must
+    be rejected like any other missing tag name, not create a tag
+    literally called "__new_tag__"."""
+    helpers.create_project(db_conn, "proj-t1d", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t1d")
+    crash_id = helpers.create_crash(db_conn, "proj-t1d", "1.0", device_id)
+
+    resp = client.post(f"/projects/proj-t1d/{crash_id}/tags", data={"tag_name": "__new_tag__"})
+    assert resp.status_code == 400
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM tag WHERE project_name = %s", ("proj-t1d",))
+        assert cur.fetchone()[0] == 0
+
+
 def test_remove_crash_tag(client, db_conn):
     helpers.create_project(db_conn, "proj-t3", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-t3")
@@ -97,6 +132,21 @@ def test_crash_page_tag_picker_is_a_visible_select(client, db_conn):
     assert '<option value="unattached-tag"' in body
     assert "<datalist" not in body
     assert 'name="new_tag_name"' in body
+
+
+def test_crash_page_new_tag_fields_are_hidden_until_new_tag_selected(client, db_conn):
+    """The new-tag name/description inputs must start hidden - they're
+    only meant to appear once "+ New tag..." is picked in the dropdown."""
+    helpers.create_project(db_conn, "proj-t4c", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-t4c")
+    crash_id = helpers.create_crash(db_conn, "proj-t4c", "1.0", device_id)
+
+    resp = client.get(f"/projects/proj-t4c/{crash_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert '<option value="__new_tag__">+ New tag' in body
+    assert 'id="new-tag-fields"' in body
+    assert 'style="display:none"' in body
 
 
 def test_list_project_crashes_tag_filter(client, db_conn):


### PR DESCRIPTION
## Summary
- The crash page's add-tag form always showed the "New tag name" + "Description" text boxes right next to the existing-tags dropdown, even when just picking an existing tag - a bit cluttered.
- Added a "+ New tag..." option to the `<select>`; the two new-tag fields now start hidden and only appear (via plain JS on the select's `change` event, no framework) once that option is picked. Switching back to an existing tag clears and re-hides them.
- The new option's value (`__new_tag__`) is purely a UI sentinel. `app/routes/tags.py` now explicitly ignores it as a fallback tag name, so submitting it without typing a name still 400s ("Missing tag_name") instead of creating a tag literally called `__new_tag__` - covers the case where JS didn't run.

## Test plan
- [x] Full `pytest` suite green (184 passed, 1 skipped), including new coverage: the "+ New tag..." option and hidden-by-default fields render, selecting the sentinel with a typed name creates that tag (not the sentinel string), and the sentinel alone (no typed name) is rejected with 400 and creates nothing.
- [ ] The show/hide toggle itself is plain client-side JS I couldn't visually verify in a real browser in this environment - worth a quick look after deploy.