### PR TITLE
Strip tool-call narration out of stored AI crash summaries

### DIFF
--- a/esp-crash-server/app/ai_tagging.py
+++ b/esp-crash-server/app/ai_tagging.py
@@ -122,19 +122,31 @@ def summarize_and_tag(crash_id, project_name):
             "content": (
                 f"Crash {crash_id} in project '{project_name}' was just symbolicated. "
                 "Use the esp-crash MCP tools: call get_crash to read its details, and "
-                "list_tags to see this project's existing tags. Write a short (2-3 "
-                "sentence) plain-English summary of what the crash is and its likely "
-                "cause. Then call add_tag_to_crash once per tag that fits - reuse an "
-                "existing tag whenever one applies, and only create a new tag when "
-                "nothing existing fits. Do not remove any existing tags. Respond with "
-                "only the summary text, nothing else."
+                "list_tags to see this project's existing tags. Then call add_tag_to_crash "
+                "once per tag that fits - reuse an existing tag whenever one applies, and "
+                "only create a new tag when nothing existing fits. Do not remove any "
+                "existing tags. Do not narrate your steps or explain what you're about to "
+                "do before or between tool calls - make all the tool calls first, then send "
+                "one final message containing nothing but a short (2-3 sentence) "
+                "plain-English summary of what the crash is and its likely cause. That "
+                "final message is shown as-is to a human reading the crash report, so it "
+                "must not include any preamble, tool narration, or markdown."
             ),
         }],
     )
 
-    summary = "".join(
-        block.text for block in response.content if block.type == "text"
-    ).strip()
+    # response.content is the full flattened transcript of the server-side
+    # tool-use turns (text, tool_use, tool_result, text, tool_use, ...,
+    # text) - only the trailing run of text blocks is the final answer;
+    # earlier text blocks are narration Claude produced between tool calls
+    # ("I'll start by...", "Now I'll tag this...") and must not end up in
+    # the stored summary.
+    summary_blocks = []
+    for block in reversed(response.content):
+        if block.type != "text":
+            break
+        summary_blocks.append(block.text)
+    summary = "\n\n".join(reversed(summary_blocks)).strip()
 
     db.session.execute(
         update(Crash).where(Crash.crash_id == crash_id).values(ai_summary=summary)

--- a/esp-crash-server/tests/test_ai_tagging.py
+++ b/esp-crash-server/tests/test_ai_tagging.py
@@ -12,9 +12,16 @@ class _FakeTextBlock:
         self.text = text
 
 
+class _FakeToolUseBlock:
+    """Stands in for an mcp_tool_use/mcp_tool_result block - anything
+    non-text - without needing the real SDK's block shape."""
+    def __init__(self):
+        self.type = "mcp_tool_use"
+
+
 class _FakeResponse:
-    def __init__(self, text):
-        self.content = [_FakeTextBlock(text)]
+    def __init__(self, text=None, blocks=None):
+        self.content = blocks if blocks is not None else [_FakeTextBlock(text)]
 
 
 class _FakeMessages:
@@ -70,6 +77,74 @@ def test_summarize_and_tag_writes_summary_and_calls_mcp_connector(app, db_conn, 
     with db_conn.cursor() as cur:
         cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
         assert cur.fetchone()[0] == summary_text
+
+
+def test_summarize_and_tag_strips_narration_between_tool_calls(app, db_conn, monkeypatch):
+    """response.content is the full flattened transcript of the server-side
+    tool-use turns - text blocks Claude produced before/between tool calls
+    ("I'll start by...", "Now I'll tag this...") must not end up glued onto
+    the stored summary; only the trailing run of text blocks (the final
+    answer) should."""
+    calls = []
+    final_summary = "A division by zero occurred in the WiFi beacon parser."
+    blocks = [
+        _FakeTextBlock("I'll help you analyze the crash. Let me start by getting the details."),
+        _FakeToolUseBlock(),
+        _FakeTextBlock("Now I'll tag this crash with the appropriate tags."),
+        _FakeToolUseBlock(),
+        _FakeTextBlock(final_summary),
+    ]
+    fake_response = _FakeResponse(blocks=blocks)
+    monkeypatch.setattr(
+        ai_tagging, "Anthropic",
+        lambda api_key=None: _FakeAnthropicClient(fake_response, calls),
+    )
+
+    helpers.create_project(db_conn, "proj-ai-narration", github_user="alice")
+    device_id = helpers.create_device(db_conn, "dev-ai-narration")
+    crash_id = helpers.create_crash(db_conn, "proj-ai-narration", "1.0", device_id, dump="symbolicated text")
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(crash_id, "proj-ai-narration")
+
+    assert result == final_summary
+    assert "I'll help you analyze" not in result
+    assert "Now I'll tag this crash" not in result
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT ai_summary FROM crash WHERE crash_id = %s", (crash_id,))
+        assert cur.fetchone()[0] == final_summary
+
+
+def test_summarize_and_tag_joins_multiple_trailing_text_blocks(app, db_conn, monkeypatch):
+    calls = []
+    blocks = [
+        _FakeToolUseBlock(),
+        _FakeTextBlock("First part."),
+        _FakeTextBlock("Second part."),
+    ]
+    fake_response = _FakeResponse(blocks=blocks)
+    monkeypatch.setattr(
+        ai_tagging, "Anthropic",
+        lambda api_key=None: _FakeAnthropicClient(fake_response, calls),
+    )
+
+    helpers.create_project(db_conn, "proj-ai-multi-text", github_user="alice")
+    device_id = helpers.create_device(db_conn, "dev-ai-multi-text")
+    crash_id = helpers.create_crash(db_conn, "proj-ai-multi-text", "1.0", device_id, dump="symbolicated text")
+
+    app.config["ANTHROPIC_API_KEY"] = "sk-test"
+    app.config["MCP_PUBLIC_URL"] = "https://mcp-esp-crash.example"
+    app.config["MCP_SERVICE_TOKEN"] = "svc-token"
+
+    with app.app_context():
+        result = ai_tagging.summarize_and_tag(crash_id, "proj-ai-multi-text")
+
+    assert result == "First part.\n\nSecond part."
 
 
 def test_summarize_and_tag_reuses_exact_duplicate_without_calling_api(app, db_conn, monkeypatch):


### PR DESCRIPTION
## Summary
Root cause of the garbled summaries (e.g. "(Same as crash #104837.) I'll help you analyze the crash. Let me start by getting the crash details and the available tags for the project.Now I'll tag this crash with the appropriate tags. The crash is a division by zero..."):

- `response.content` from the MCP-connector call is the **full flattened transcript** of the server-side agentic tool-use turns: text, tool_use, tool_result, text, tool_use, tool_result, ..., text. Claude naturally narrates between tool calls ("I'll start by...", "Now I'll tag this...").
- The old code joined **every** text block in that transcript with no separator, so all of that narration ended up glued directly onto the actual summary.

Fix:
- Only keep the **trailing contiguous run of text blocks** (the final answer, after every tool call is done) - earlier narration blocks are discarded. Joined with a blank line in case the final answer itself spans more than one text block.
- Tightened the prompt: explicitly told not to narrate steps, to make all tool calls first, then send one final message containing only the summary.

Not in scope: already-stored bad summaries aren't touched. `ai_summary` is a one-time cache specifically to avoid re-analyzing (see the exact-dump/signature dedup tiers) - nothing re-runs automatically. A bad one can be cleared manually (`UPDATE crash SET ai_summary = NULL WHERE ...`) to have it regenerated on the next cron tick, at the cost of one more API call.

## Test plan
- [x] Full `pytest` suite green (187 passed, 1 skipped), including new coverage: narration text blocks interspersed with tool-use blocks are stripped and only the final block is kept, and multiple trailing text blocks are joined with a blank line rather than concatenated raw.