### PR TITLE
Hide the Modules column on the crash list when the page has none

### DIFF
--- a/esp-crash-server/app/routes/projects.py
+++ b/esp-crash-server/app/routes/projects.py
@@ -125,9 +125,14 @@ def list_project_crashes(project_name):
             select(Tag.name).where(Tag.tag_id == tag_id)
         ).scalar_one_or_none()
 
+    # Only worth a whole column if at least one crash on this page actually
+    # references a module - otherwise it's just an empty-dash column on
+    # every row.
+    any_modules = any(c["module_names"] for c in crashes)
+
     # crash.module_names is populated at cron processing time, so no per-row
     # coredump parsing happens here.
-    return render_template('project.html', crashes = crashes, project_name = project_name, search = search or "", limit = limit, offset = offset, tag_id = tag_id, active_tag = active_tag, signature = signature, full_count = crashes[0]["full_count"] if len(crashes) > 0 else 0)
+    return render_template('project.html', crashes = crashes, project_name = project_name, search = search or "", limit = limit, offset = offset, tag_id = tag_id, active_tag = active_tag, signature = signature, any_modules = any_modules, full_count = crashes[0]["full_count"] if len(crashes) > 0 else 0)
 
 
 @login_required

--- a/esp-crash-server/templates/project.html
+++ b/esp-crash-server/templates/project.html
@@ -59,7 +59,9 @@ endblock %}
                 {% endif %}
                 <th scope="col" class="px-6 py-3">Project Version</th>
                 <th scope="col" class="px-6 py-3">Device Id</th>
+                {% if any_modules %}
                 <th scope="col" class="px-6 py-3">Modules</th>
+                {% endif %}
                 <th scope="col" class="px-6 py-3">Tags</th>
                 <th scope="col" class="px-6 py-3"></th>
             </tr>
@@ -98,6 +100,7 @@ endblock %}
                     </a>
                     {% endif %}
                 </td>
+                {% if any_modules %}
                 <td class="px-6 py-4">
                     {% if crash.module_names %}
                     <div class="flex flex-wrap gap-1">
@@ -111,6 +114,7 @@ endblock %}
                     <span class="text-gray-300">&mdash;</span>
                     {% endif %}
                 </td>
+                {% endif %}
                 <td class="px-6 py-4">
                     {% if crash.tags %}
                     <div class="flex flex-wrap gap-1">

--- a/esp-crash-server/tests/helpers.py
+++ b/esp-crash-server/tests/helpers.py
@@ -25,12 +25,12 @@ def create_device(db_conn, ext_device_id, alias=None):
         return cur.fetchone()[0]
 
 
-def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None, ai_summary=None, date=None, signature=None):
+def create_crash(db_conn, project_name, project_ver, device_id, crash_dmp=b"raw-dump-bytes", dump=None, ai_summary=None, date=None, signature=None, module_names=None):
     with db_conn.cursor() as cur:
         cur.execute(
-            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump, ai_summary, signature)
-               VALUES (COALESCE(%s, NOW()), %s, %s, %s, %s, %s, %s, %s) RETURNING crash_id""",
-            (date, project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump, ai_summary, signature),
+            """INSERT INTO crash (date, project_name, project_ver, crash_dmp, device_id, dump, ai_summary, signature, module_names)
+               VALUES (COALESCE(%s, NOW()), %s, %s, %s, %s, %s, %s, %s, %s) RETURNING crash_id""",
+            (date, project_name, project_ver, psycopg2.Binary(crash_dmp), device_id, dump, ai_summary, signature, module_names),
         )
         return cur.fetchone()[0]
 

--- a/esp-crash-server/tests/test_routes_projects.py
+++ b/esp-crash-server/tests/test_routes_projects.py
@@ -34,6 +34,30 @@ def test_list_project_crashes_shows_seeded_crash(client, db_conn):
     assert b"dev-1" in resp.data
 
 
+def test_list_project_crashes_hides_modules_column_when_none_referenced(client, db_conn):
+    helpers.create_project(db_conn, "proj-no-modules", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-no-modules")
+    helpers.create_crash(db_conn, "proj-no-modules", "1.0", device_id)
+
+    resp = client.get("/projects/proj-no-modules")
+    assert resp.status_code == 200
+    assert b">Modules<" not in resp.data
+
+
+def test_list_project_crashes_shows_modules_column_when_referenced(client, db_conn):
+    helpers.create_project(db_conn, "proj-with-modules", github_user="none")
+    device_id = helpers.create_device(db_conn, "dev-with-modules")
+    # One crash with modules, one without - the column must still show
+    # since at least one crash on the page has content for it.
+    helpers.create_crash(db_conn, "proj-with-modules", "1.0", device_id, module_names=["libfoo"])
+    helpers.create_crash(db_conn, "proj-with-modules", "1.0", device_id)
+
+    resp = client.get("/projects/proj-with-modules")
+    assert resp.status_code == 200
+    assert b">Modules<" in resp.data
+    assert b"libfoo" in resp.data
+
+
 def test_list_project_crashes_search_filters(client, db_conn):
     helpers.create_project(db_conn, "proj-z", github_user="none")
     device_id = helpers.create_device(db_conn, "dev-2")


### PR DESCRIPTION
## Summary
- `list_project_crashes` now computes `any_modules` (true if at least one crash on the current page has `module_names`) and passes it to the template.
- `project.html` skips the Modules column entirely (both the `<th>` header and each row's `<td>`) when `any_modules` is false, instead of showing a column of dashes.
- Scoped per-page, not per-project: if any crash on the current page/filter references a module, the column still shows (with a dash for rows that don't).

## Test plan
- [x] Full `pytest` suite green (189 passed, 1 skipped), including new coverage: the column is absent when no crash on the page has modules, and present (with the module badge rendered) when at least one does even if others on the same page don't.