### PR TITLE
Expose crash signature via MCP - field + list_crashes filter

### DIFF
--- a/esp-crash-server/mcp_app/server.py
+++ b/esp-crash-server/mcp_app/server.py
@@ -105,20 +105,26 @@ def build_app():
         project_name: str | None = None,
         search: str | None = None,
         tag_id: int | None = None,
+        signature: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict]:
         """List crashes across your projects (newest first). Optionally filter
-        by project_name, a full-text search string, and/or tag_id (see
-        list_tags for a project's available tag_ids)."""
+        by project_name, a full-text search string, tag_id (see list_tags for
+        a project's available tag_ids), and/or signature - a non-AI
+        duplicate-grouping fingerprint each crash carries; pass another
+        crash's `signature` field (from list_crashes/get_crash) to find every
+        crash with the same likely root cause, the same thing the web UI's
+        "Related" link does."""
         with flask_app.app_context():
-            return tools.list_crashes(_current_user(), project_name, search, tag_id, limit, offset)
+            return tools.list_crashes(_current_user(), project_name, search, tag_id, signature, limit, offset)
 
     @mcp.tool()
     def get_crash(crash_id: int) -> dict | None:
-        """Get full detail for one crash, including the symbolicated dump and
-        the ELF builds available for its project/version. Null if not found or
-        not accessible to you."""
+        """Get full detail for one crash, including the symbolicated dump, the
+        ELF builds available for its project/version, and its `signature` (a
+        non-AI duplicate-grouping fingerprint - pass it to list_crashes to
+        find related crashes). Null if not found or not accessible to you."""
         with flask_app.app_context():
             return tools.get_crash(_current_user(), crash_id)
 

--- a/esp-crash-server/mcp_app/tools.py
+++ b/esp-crash-server/mcp_app/tools.py
@@ -75,10 +75,14 @@ def list_projects(github_user):
     return [_serialize(r) for r in rows]
 
 
-def list_crashes(github_user, project_name=None, search=None, tag_id=None, limit=50, offset=0):
+def list_crashes(github_user, project_name=None, search=None, tag_id=None, signature=None, limit=50, offset=0):
     """Crashes across the caller's projects, newest first. Optional project
-    filter, full-text search (matches the web crash list's textsearch), and
-    tag_id filter (see list_tags for a project's available tag_ids)."""
+    filter, full-text search (matches the web crash list's textsearch),
+    tag_id filter (see list_tags for a project's available tag_ids), and
+    signature filter - a non-AI duplicate-grouping fingerprint (see
+    app/crash_signature.py); pass another crash's `signature` field to find
+    ones with the same likely root cause, the same thing the web UI's
+    "Related" link does."""
     conditions = [ProjectAuth.github == github_user]
     if project_name:
         conditions.append(Crash.project_name == project_name)
@@ -86,10 +90,12 @@ def list_crashes(github_user, project_name=None, search=None, tag_id=None, limit
         conditions.append(Crash.textsearch.op("@@")(func.plainto_tsquery(search)))
     if tag_id:
         conditions.append(Crash.crash_id.in_(select(CrashTag.crash_id).where(CrashTag.tag_id == tag_id)))
+    if signature:
+        conditions.append(Crash.signature == signature)
     rows = db.session.execute(
         select(
             Crash.crash_id, Crash.date, Crash.project_name, Crash.project_ver,
-            Crash.device_id, Crash.module_names, Crash.ai_summary,
+            Crash.device_id, Crash.module_names, Crash.ai_summary, Crash.signature,
             Device.ext_device_id, Device.alias,
         )
         .select_from(Crash)
@@ -116,6 +122,7 @@ def get_crash(github_user, crash_id):
             Crash.crash_id, Crash.date, Crash.project_name, Crash.project_ver,
             Crash.device_id, Device.ext_device_id, Device.alias,
             Crash.dump, Crash.module_map, Crash.module_names, Crash.ai_summary,
+            Crash.signature,
         )
         .select_from(Crash)
         .join(ProjectAuth, Crash.project_name == ProjectAuth.project_name)

--- a/esp-crash-server/tests/test_mcp_tools.py
+++ b/esp-crash-server/tests/test_mcp_tools.py
@@ -259,6 +259,45 @@ def test_list_crashes_tag_filter(app, db_conn, ctx):
     assert {c["crash_id"] for c in unfiltered} == {crash_1, crash_2}
 
 
+def test_list_crashes_signature_filter(app, db_conn, ctx):
+    helpers.create_project(db_conn, "proj-a", github_user="alice")
+    dev = helpers.create_device(db_conn, "dev-1")
+    sig = "a" * 64
+    crash_1 = helpers.create_crash(db_conn, "proj-a", "1.0", dev, signature=sig)
+    crash_2 = helpers.create_crash(db_conn, "proj-a", "1.0", dev, signature=sig)
+    helpers.create_crash(db_conn, "proj-a", "1.0", dev)  # different signature (none) - must not match
+
+    filtered = tools.list_crashes("alice", signature=sig)
+    assert {c["crash_id"] for c in filtered} == {crash_1, crash_2}
+    assert all(c["signature"] == sig for c in filtered)
+
+
+def test_list_crashes_signature_filter_scoped_to_caller(app, db_conn, ctx):
+    """The signature filter must still respect project ACLs - it's not a
+    backdoor around list_crashes's normal scoping."""
+    sig = "b" * 64
+    helpers.create_project(db_conn, "proj-a", github_user="alice")
+    dev_a = helpers.create_device(db_conn, "dev-a")
+    helpers.create_crash(db_conn, "proj-a", "1.0", dev_a, signature=sig)
+
+    helpers.create_project(db_conn, "proj-b", github_user="bob")
+    dev_b = helpers.create_device(db_conn, "dev-b")
+    helpers.create_crash(db_conn, "proj-b", "1.0", dev_b, signature=sig)
+
+    alice_view = tools.list_crashes("alice", signature=sig)
+    assert [c["project_name"] for c in alice_view] == ["proj-a"]
+
+
+def test_get_crash_includes_signature(app, db_conn, ctx):
+    helpers.create_project(db_conn, "proj-a", github_user="alice")
+    dev = helpers.create_device(db_conn, "dev-1")
+    sig = "c" * 64
+    crash_id = helpers.create_crash(db_conn, "proj-a", "1.0", dev, signature=sig)
+
+    crash = tools.get_crash("alice", crash_id)
+    assert crash["signature"] == sig
+
+
 def test_get_crash_includes_tags(app, db_conn, ctx):
     helpers.create_project(db_conn, "proj-a", github_user="alice")
     dev = helpers.create_device(db_conn, "dev-1")


### PR DESCRIPTION
## Summary
`signature` (the non-AI duplicate-grouping fingerprint from `app/crash_signature.py`, already used for web-UI dedup and the "Related" link) was never exposed through the MCP tools - `list_crashes`/`get_crash` didn't select it, and there was no way to filter by it, unlike the web UI's `?signature=` filter.

- `get_crash` and `list_crashes` results now include `signature`.
- `list_crashes` gains a `signature` filter param (mirrors the existing `tag_id` filter pattern) - pass another crash's `signature` to find every crash with the same likely root cause, scoped by the caller's normal project ACLs like every other filter.
- Updated both tool docstrings so an MCP client (including the AI-tagging bot) knows this exists.

## Test plan
- [x] Full `pytest` suite green (192 passed, 1 skipped), including new coverage: `signature` present in `get_crash`/`list_crashes` output, the `signature` filter matches only same-signature crashes, and it still respects per-user project ACL scoping (not a backdoor around the normal caller-scoping).