### PR TITLE
Fix external_url_for crashing outside a request context

### DIFF
--- a/esp-crash-server/app/rendering.py
+++ b/esp-crash-server/app/rendering.py
@@ -15,19 +15,21 @@ def format_datetime(value, format='%Y-%m-%d %H:%M:%S'):
 
 
 def external_url_for(endpoint, **values):
-    """Generate external URL for Slack notifications."""
-    external_url = current_app.config.get("EXTERNAL_URL")
-    if external_url:
-        # Remove trailing slash from external URL
-        external_url = external_url.rstrip('/')
-        # Generate the path using url_for
-        with current_app.app_context():
-            path = url_for(endpoint, **values)
-        return f"{external_url}{path}"
-    else:
-        # Fallback to regular url_for with _external=True
-        with current_app.app_context():
-            return url_for(endpoint, _external=True, **values)
+    """Generate external URL for Slack/webhook notifications.
+
+    url_for() needs an active *request* context to build anything (a bare
+    app_context isn't enough - it raises "Unable to build URLs outside an
+    active request without 'SERVER_NAME' configured"). That's always been
+    true during a real HTTP request (this app doesn't set SERVER_NAME), but
+    cron_runner.py (see cron_runner.py/_tick) calls into cron() with only
+    an app context, no request - so push a throwaway test_request_context
+    to give url_for something to hang off regardless of which of those two
+    ways we got here."""
+    external_url = (current_app.config.get("EXTERNAL_URL") or "").rstrip('/')
+    with current_app.test_request_context(base_url=external_url or None):
+        if external_url:
+            return f"{external_url}{url_for(endpoint, **values)}"
+        return url_for(endpoint, _external=True, **values)
 
 
 def render_template(template_name, **context):

--- a/esp-crash-server/tests/test_rendering.py
+++ b/esp-crash-server/tests/test_rendering.py
@@ -1,0 +1,69 @@
+"""Tests for app/rendering.py's external_url_for - specifically that it
+works with only an app context active and no request context, which is how
+cron_runner.py's direct (non-HTTP) calls into cron() run. Regression test
+for "RuntimeError: Unable to build URLs outside an active request without
+'SERVER_NAME' configured", seen in production after the cron-local-runner
+refactor moved cron() off the HTTP request path that used to supply one."""
+import helpers
+from app.rendering import external_url_for
+
+
+def test_external_url_for_works_without_a_request_context(app, monkeypatch):
+    monkeypatch.setitem(app.config, "EXTERNAL_URL", "https://esp-crash.example")
+    with app.app_context():
+        url = external_url_for("show_project_crash", project_name="proj-a", crash_id=123)
+    assert url == "https://esp-crash.example/projects/proj-a/123"
+
+
+def test_external_url_for_falls_back_to_url_for_external_true(app, monkeypatch):
+    """No EXTERNAL_URL configured - falls back to url_for(..., _external=True),
+    which also needs a request context to build anything."""
+    monkeypatch.setitem(app.config, "EXTERNAL_URL", "")
+    with app.app_context():
+        url = external_url_for("show_project_crash", project_name="proj-a", crash_id=123)
+    assert url.startswith("http")
+    assert url.endswith("/projects/proj-a/123")
+
+
+def test_cron_webhook_notification_survives_without_a_request_context(app, db_conn, monkeypatch):
+    """End-to-end regression check: a cron tick that sends a webhook (which
+    calls external_url_for) must not fail when run the way cron_runner.py
+    runs it - inside only an app context, no request."""
+    import requests
+    from app import decode
+    from app.routes.cron import cron
+
+    monkeypatch.setitem(app.config, "EXTERNAL_URL", "https://esp-crash.example")
+
+    def fake_resolve(dump_path, prog_path):
+        import os
+        import tempfile
+        fd, core_elf = tempfile.mkstemp()
+        os.close(fd)
+        return ([], [], "base panic text\n", core_elf, [])
+
+    monkeypatch.setattr(decode, "_resolve_modules_for_dump", fake_resolve)
+
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append((url, json))
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    device_id = helpers.create_device(db_conn, "dev-cron-render-regress")
+    helpers.create_elf_file(db_conn, "proj-cron-render-regress", "1.0")
+    helpers.create_crash(db_conn, "proj-cron-render-regress", "1.0", device_id, crash_dmp=b"raw-dump")
+    helpers.create_webhook(db_conn, "proj-cron-render-regress", "https://hooks.test/notify")
+
+    with app.app_context():
+        result = cron()  # must not raise
+
+    assert result == ("OK\n", 200)
+    assert len(calls) == 1
+    assert calls[0][1]["details_url"].startswith("https://esp-crash.example/")


### PR DESCRIPTION
## Summary
Regression from #26 (running cron locally instead of curling the backend). `cron_runner.py` calls `cron()` inside only an app context, no request context. `external_url_for`'s `url_for()` calls need a request context to build anything at all - that was always true before only because `cron()` used to run inside a live HTTP request (the old curl-loop trigger supplied it for free). The old code's `with current_app.app_context():` wrap around `url_for()` never actually fixed this - an app context alone isn't sufficient; Flask still raises:

```
RuntimeError: Unable to build URLs outside an active request without 'SERVER_NAME' configured.
```

Every crash that has a project webhook or Slack integration configured hits this on every cron tick and fails the whole tick (symbolication + signature backfill earlier in the same tick still complete and commit fine - only the webhook/Slack notification step, and everything after it in that tick, fails).

Fix: push a throwaway `test_request_context()` inside `external_url_for` instead, which gives `url_for` something to hang off regardless of whether the caller already has a real request context (e.g. `app/routes/slack.py`'s "test webhook" button) or none at all (`cron_runner.py`).

## Test plan
- [x] New `tests/test_rendering.py` reproduces the exact production traceback with the old code (verified by temporarily reverting the fix and re-running - all 3 new tests fail with the identical `RuntimeError`), and passes with the fix. Includes an end-to-end test calling `cron()` directly inside only an app context (no test client / no request) with a real webhook configured, matching exactly how `cron_runner.py` invokes it in production.
- [x] Full `pytest` suite green (195 passed, 1 skipped).